### PR TITLE
use lower case strings for traceid

### DIFF
--- a/xray/handler.go
+++ b/xray/handler.go
@@ -102,7 +102,7 @@ func Handler(sn SegmentNamer, h http.Handler) http.Handler {
 
 		trace := parseHeaders(r.Header)
 		if trace["Root"] != "" {
-			seg.TraceID = trace["Root"]
+			seg.TraceID = strings.ToLower(trace["Root"])
 			seg.RequestWasTraced = true
 		}
 		if trace["Parent"] != "" {
@@ -112,7 +112,7 @@ func Handler(sn SegmentNamer, h http.Handler) http.Handler {
 		// send back the root and possibly sampled values.
 		var respHeader bytes.Buffer
 		respHeader.WriteString("Root=")
-		respHeader.WriteString(seg.TraceID)
+		respHeader.WriteString(strings.ToLower(seg.TraceID))
 		switch trace["Sampled"] {
 		case "0":
 			seg.Sampled = false

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -13,6 +13,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-xray-sdk-go/header"
@@ -114,8 +115,9 @@ func NewSegmentFromHeader(ctx context.Context, name string, h *header.Header) (c
 	con, seg := BeginSegment(ctx, name)
 
 	if h.TraceID != "" {
-		seg.TraceID = h.TraceID
+		seg.TraceID = strings.ToLower(h.TraceID)
 	}
+
 	if h.ParentID != "" {
 		seg.ParentID = h.ParentID
 	}


### PR DESCRIPTION
My use case is to have a something create the Trace ID before reaching the Go app, however that service only generates uppercase strings and Xray only accepts lowercase strings.  