### PR TITLE
Overall cleanup and readability improvements

### DIFF
--- a/header/header.go
+++ b/header/header.go
@@ -112,7 +112,7 @@ func (h Header) String() string {
 	}
 	p = append(p, []byte(h.SamplingDecision))
 	for key := range h.AdditionalData {
-		p = append(p, []byte(key+"="+string(h.AdditionalData[key])))
+		p = append(p, []byte(key+"="+h.AdditionalData[key]))
 	}
 	return string(bytes.Join(p, []byte(";")))
 }

--- a/header/header.go
+++ b/header/header.go
@@ -83,18 +83,20 @@ func FromString(s string) *Header {
 	for i := range parts {
 		p := strings.TrimSpace(parts[i])
 		value, valid := valueFromKeyValuePair(p)
-		if valid {
-			if strings.HasPrefix(p, RootPrefix) {
-				ret.TraceID = value
-			} else if strings.HasPrefix(p, ParentPrefix) {
-				ret.ParentID = value
-			} else if strings.HasPrefix(p, SampledPrefix) {
-				ret.SamplingDecision = samplingDecision(p)
-			} else if !strings.HasPrefix(p, SelfPrefix) {
-				key, valid := keyFromKeyValuePair(p)
-				if valid {
-					ret.AdditionalData[key] = value
-				}
+		if !valid {
+			continue
+		}
+
+		if strings.HasPrefix(p, RootPrefix) {
+			ret.TraceID = value
+		} else if strings.HasPrefix(p, ParentPrefix) {
+			ret.ParentID = value
+		} else if strings.HasPrefix(p, SampledPrefix) {
+			ret.SamplingDecision = samplingDecision(p)
+		} else if !strings.HasPrefix(p, SelfPrefix) {
+			key, valid := keyFromKeyValuePair(p)
+			if valid {
+				ret.AdditionalData[key] = value
 			}
 		}
 	}

--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -13,7 +13,7 @@ import (
 )
 
 // InstancePluginMetadata points to the PluginMetadata struct.
-var InstancePluginMetadata *PluginMetadata = &PluginMetadata{}
+var InstancePluginMetadata = &PluginMetadata{}
 
 // PluginMetadata struct contains items to record information
 // about the AWS infrastructure hosting the traced application.

--- a/pattern/search_pattern.go
+++ b/pattern/search_pattern.go
@@ -18,7 +18,7 @@ func WildcardMatchCaseInsensitive(pattern string, text string) bool {
 	return WildcardMatch(pattern, text, true)
 }
 
-// WildcardMatchCaseInsensitive returns true if text matches pattern at the given case-sensitivity; returns false otherwise.
+// WildcardMatch returns true if text matches pattern at the given case-sensitivity; returns false otherwise.
 func WildcardMatch(pattern string, text string, caseInsensitive bool) bool {
 	patternLen := len(pattern)
 	textLen := len(text)

--- a/pattern/search_pattern.go
+++ b/pattern/search_pattern.go
@@ -49,20 +49,21 @@ func WildcardMatch(pattern string, text string, caseInsensitive bool) bool {
 				t := text[i]
 				res[i+1] = res[i] && ('?' == p || t == p)
 			}
-		} else {
-			i := 0
-			for i <= textLen && !res[i] {
-				i++
-			}
-			for i <= textLen {
-				res[i] = true
-				i++
-			}
+			res[0] = res[0] && '*' == p
+			continue
+		}
+
+		i := 0
+		for i <= textLen && !res[i] {
+			i++
+		}
+		for i <= textLen {
+			res[i] = true
+			i++
 		}
 		res[0] = res[0] && '*' == p
 	}
 	return res[textLen]
-
 }
 
 func simpleWildcardMatch(pattern string, text string) bool {
@@ -73,21 +74,24 @@ func simpleWildcardMatch(pattern string, text string) bool {
 		p := pattern[i]
 		if '*' == p {
 			return true
-		} else if '?' == p {
+		}
+
+		if '?' == p {
 			if textLen == j {
 				return false
 			}
 			j++
-		} else {
-			if j >= textLen {
-				return false
-			}
-			t := text[j]
-			if p != t {
-				return false
-			}
-			j++
+			continue
 		}
+
+		if j >= textLen {
+			return false
+		}
+		t := text[j]
+		if p != t {
+			return false
+		}
+		j++
 	}
 	return j == textLen
 }

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -25,6 +25,7 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	sess, e := session.NewSession()
 	if e != nil {
 		log.Errorf("Unable to create a new ec2 session: %v", e)
+		return
 	}
 	client := ec2metadata.New(sess)
 	doc, err := client.GetInstanceIdentityDocument()

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -22,11 +22,11 @@ func init() {
 }
 
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
-	session, e := session.NewSession()
+	sess, e := session.NewSession()
 	if e != nil {
 		log.Errorf("Unable to create a new ec2 session: %v", e)
 	}
-	client := ec2metadata.New(session)
+	client := ec2metadata.New(sess)
 	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
 		log.Errorf("Unable to read EC2 instance metadata: %v", err)

--- a/strategy/sampling/reservoir.go
+++ b/strategy/sampling/reservoir.go
@@ -9,7 +9,6 @@
 package sampling
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -33,7 +32,7 @@ type Reservoir struct {
 // desired capacity is greater than this maximum value.
 func NewReservoir(perSecond uint64) (res *Reservoir, err error) {
 	if perSecond >= maxRate {
-		return nil, errors.New(fmt.Sprintf("Desired sampling capacity of %d is greater than maximum supported rate %d", perSecond, maxRate))
+		return nil, fmt.Errorf("desired sampling capacity of %d is greater than maximum supported rate %d", perSecond, maxRate)
 	}
 	return &Reservoir{
 		maskedCounter: 0,
@@ -48,8 +47,8 @@ func NewReservoir(perSecond uint64) (res *Reservoir, err error) {
 // Take returns true.
 func (r *Reservoir) Take() bool {
 	now := uint64(time.Now().Unix())
-	new := atomic.AddUint64(&r.maskedCounter, 1)
-	previousTimestamp := extractTime(new)
+	counterNewVal := atomic.AddUint64(&r.maskedCounter, 1)
+	previousTimestamp := extractTime(counterNewVal)
 
 	if previousTimestamp != now {
 		r.mutex.Lock()
@@ -61,11 +60,11 @@ func (r *Reservoir) Take() bool {
 			atomic.StoreUint64(&r.maskedCounter, valueToSet)
 		}
 
-		new = atomic.AddUint64(&r.maskedCounter, 1)
+		counterNewVal = atomic.AddUint64(&r.maskedCounter, 1)
 		r.mutex.Unlock()
 	}
 
-	newCounterValue := extractCounter(new)
+	newCounterValue := extractCounter(counterNewVal)
 	return newCounterValue <= r.perSecond
 }
 

--- a/strategy/sampling/reservoir_test.go
+++ b/strategy/sampling/reservoir_test.go
@@ -53,5 +53,5 @@ func TestTenPerSecond(t *testing.T) {
 func TestDesiredRateTooLarge(t *testing.T) {
 	per := 1e9
 	_, err := NewReservoir(uint64(per))
-	assert.EqualError(t, err, fmt.Sprintf("Desired sampling capacity of %d is greater than maximum supported rate %d", uint64(per), uint64(1e8)))
+	assert.EqualError(t, err, fmt.Sprintf("desired sampling capacity of %d is greater than maximum supported rate %d", uint64(per), uint64(1e8)))
 }

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -267,9 +267,9 @@ func (j *jsonMap) search(keys ...string) *jsonMap {
 			if !ok {
 				return nil
 			}
-		} else {
-			return nil
 		}
+
+		return nil
 	}
 	return &jsonMap{object}
 }
@@ -315,16 +315,18 @@ func extractParameters(whitelistKey string, rType int, r *request.Request, white
 			return
 		}
 		for _, child := range children {
-			if child != nil {
-				var value interface{}
-				if rType == requestKeyword {
-					value = keyValue(r.Params, child.(string))
-				} else if rType == responseKeyword {
-					value = keyValue(r.Data, child.(string))
-				}
-				if (value != reflect.Value{}) {
-					valueMap[child.(string)] = value
-				}
+			if child == nil {
+				continue
+			}
+
+			var value interface{}
+			if rType == requestKeyword {
+				value = keyValue(r.Params, child.(string))
+			} else if rType == responseKeyword {
+				value = keyValue(r.Data, child.(string))
+			}
+			if (value != reflect.Value{}) {
+				valueMap[child.(string)] = value
 			}
 		}
 	}

--- a/xray/config.go
+++ b/xray/config.go
@@ -90,8 +90,8 @@ func Configure(c Config) error {
 	var errors exception.MultiError
 
 	var daemonAddress string
-	if os.Getenv("AWS_XRAY_DAEMON_ADDRESS") != "" {
-		daemonAddress = os.Getenv("AWS_XRAY_DAEMON_ADDRESS")
+	if addr := os.Getenv("AWS_XRAY_DAEMON_ADDRESS"); addr != "" {
+		daemonAddress = addr
 	} else if c.DaemonAddr != "" {
 		daemonAddress = c.DaemonAddr
 	}

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -63,7 +63,7 @@ func (sms *TestStreamingStrategy) StreamCompletedSubsegments(seg *Segment) [][]b
 }
 
 func (cms *TestContextMissingStrategy) ContextMissing(v interface{}) {
-	fmt.Sprintf("Test ContextMissing Strategy %v", v)
+	fmt.Printf("Test ContextMissing Strategy %v", v)
 }
 
 func stashEnv() []string {

--- a/xray/context.go
+++ b/xray/context.go
@@ -86,7 +86,7 @@ func AddMetadataToNamespace(ctx context.Context, namespace string, key string, v
 // AddError adds an error to the provided segment or subsegment in ctx.
 func AddError(ctx context.Context, err error) error {
 	if seg := GetSegment(ctx); seg != nil {
-		return seg.addError(err)
+		return seg.AddError(err)
 	}
 	return errors.New("Unable to retrieve segment")
 }

--- a/xray/context.go
+++ b/xray/context.go
@@ -19,6 +19,9 @@ type ContextKeytype int
 // ContextKey returns a pointer to a newly allocated zero value of ContextKeytype.
 var ContextKey = new(ContextKeytype)
 
+// ErrRetrieveSegment happens when a segment cannot be retrieved
+var ErrRetrieveSegment = errors.New("unable to retrieve segment")
+
 // GetSegment returns a pointer to the segment or subsegment provided
 // in ctx, or nil if no segment or subsegment is found.
 func GetSegment(ctx context.Context) *Segment {
@@ -64,7 +67,7 @@ func AddAnnotation(ctx context.Context, key string, value interface{}) error {
 	if seg := GetSegment(ctx); seg != nil {
 		return seg.addAnnotation(key, value)
 	}
-	return errors.New("Unable to retrieve segment")
+	return ErrRetrieveSegment
 }
 
 // AddMetadata adds a metadata to the provided segment or subsegment in ctx.
@@ -72,7 +75,7 @@ func AddMetadata(ctx context.Context, key string, value interface{}) error {
 	if seg := GetSegment(ctx); seg != nil {
 		return seg.addMetadata(key, value)
 	}
-	return errors.New("Unable to retrieve segment")
+	return ErrRetrieveSegment
 }
 
 // AddMetadataToNamespace adds a namespace to the provided segment's or subsegment's metadata in ctx.
@@ -80,7 +83,7 @@ func AddMetadataToNamespace(ctx context.Context, namespace string, key string, v
 	if seg := GetSegment(ctx); seg != nil {
 		return seg.addMetadataToNamespace(namespace, key, value)
 	}
-	return errors.New("Unable to retrieve segment")
+	return ErrRetrieveSegment
 }
 
 // AddError adds an error to the provided segment or subsegment in ctx.
@@ -88,5 +91,5 @@ func AddError(ctx context.Context, err error) error {
 	if seg := GetSegment(ctx); seg != nil {
 		return seg.AddError(err)
 	}
-	return errors.New("Unable to retrieve segment")
+	return ErrRetrieveSegment
 }

--- a/xray/context_test.go
+++ b/xray/context_test.go
@@ -105,12 +105,14 @@ func TestSimpleMetadata(t *testing.T) {
 
 func TestAddError(t *testing.T) {
 	ctx, root := BeginSegment(context.Background(), "Test")
-	err := AddError(ctx, errors.New("New Error"))
+	errMsg := "new Error"
+	er := errors.New(errMsg)
+	err := AddError(ctx, er)
 	assert.Nil(t, err)
 	root.Close(err)
 	s, e := TestDaemon.Recv()
 	assert.NoError(t, e)
 
-	assert.Equal(t, "New Error", s.Cause.Exceptions[0].Message)
+	assert.Equal(t, errMsg, s.Cause.Exceptions[0].Message)
 	assert.Equal(t, "error", s.Cause.Exceptions[0].Type)
 }

--- a/xray/emitter_test.go
+++ b/xray/emitter_test.go
@@ -49,7 +49,7 @@ func TestStreamingSegmentsOnChildNode(t *testing.T) {
 	out := packSegments(seg, nil)
 	s := &Segment{}
 	json.Unmarshal(out[2], s)
-	assert.Equal(t, 20, (len(s.Subsegments)))
+	assert.Equal(t, 20, len(s.Subsegments))
 	assert.Equal(t, 3, len(out))
 }
 

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -35,8 +35,8 @@ type FixedSegmentNamer struct {
 // If the AWS_XRAY_TRACING_NAME environment variable is set,
 // its value will override the provided name argument.
 func NewFixedSegmentNamer(name string) *FixedSegmentNamer {
-	if os.Getenv("AWS_XRAY_TRACING_NAME") != "" {
-		name = os.Getenv("AWS_XRAY_TRACING_NAME")
+	if tName := os.Getenv("AWS_XRAY_TRACING_NAME"); tName != "" {
+		name = tName
 	}
 	return &FixedSegmentNamer{
 		FixedName: name,
@@ -62,8 +62,8 @@ type DynamicSegmentNamer struct {
 
 // NewDynamicSegmentNamer creates a new dynamic segment namer.
 func NewDynamicSegmentNamer(fallback string, recognized string) *DynamicSegmentNamer {
-	if os.Getenv("AWS_XRAY_TRACING_NAME") != "" {
-		fallback = os.Getenv("AWS_XRAY_TRACING_NAME")
+	if tName := os.Getenv("AWS_XRAY_TRACING_NAME"); tName != "" {
+		fallback = tName
 	}
 	return &DynamicSegmentNamer{
 		FallbackName:    fallback,

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -87,9 +87,9 @@ func Handler(sn SegmentNamer, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := sn.Name(r.Host)
 
-		header := header.FromString(r.Header.Get("x-amzn-trace-id"))
+		traceHeader := header.FromString(r.Header.Get("x-amzn-trace-id"))
 
-		ctx, seg := NewSegmentFromHeader(r.Context(), name, header)
+		ctx, seg := NewSegmentFromHeader(r.Context(), name, traceHeader)
 
 		r = r.WithContext(ctx)
 

--- a/xray/handler_test.go
+++ b/xray/handler_test.go
@@ -18,11 +18,9 @@ import (
 )
 
 func TestRootHandler(t *testing.T) {
-	var contentLength int
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		b := []byte(`200 - OK`)
-		contentLength = len(b)
 		w.Write(b)
 	})
 

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -64,14 +64,13 @@ func BeginSegment(ctx context.Context, name string) (context.Context, *Segment) 
 	seg.InProgress = true
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			seg.Lock()
-			seg.ContextDone = true
-			seg.Unlock()
-			if !seg.InProgress && !seg.Emitted {
-				seg.flush(false)
-			}
+		<-ctx.Done()
+
+		seg.Lock()
+		seg.ContextDone = true
+		seg.Unlock()
+		if !seg.InProgress && !seg.Emitted {
+			seg.flush(false)
 		}
 	}()
 
@@ -156,8 +155,8 @@ func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
 			seg.rawSubsegments[len(seg.rawSubsegments)-1] = nil
 			seg.rawSubsegments = seg.rawSubsegments[:len(seg.rawSubsegments)-1]
 
-			seg.totalSubSegments -= 1
-			seg.openSegments -= 1
+			seg.totalSubSegments--
+			seg.openSegments--
 			return true
 		}
 	}
@@ -259,6 +258,7 @@ func (seg *Segment) root() *Segment {
 	return seg.parent.root()
 }
 
+// AddError allows adding errors to the current trace segment
 func (seg *Segment) AddError(err error) error {
 	seg.Lock()
 	defer seg.Unlock()

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -139,7 +139,7 @@ func (seg *Segment) Close(err error) {
 	seg.Unlock()
 
 	if err != nil {
-		seg.addError(err)
+		seg.AddError(err)
 	}
 
 	seg.flush(false)
@@ -259,7 +259,7 @@ func (seg *Segment) root() *Segment {
 	return seg.parent.root()
 }
 
-func (seg *Segment) addError(err error) error {
+func (seg *Segment) AddError(err error) error {
 	seg.Lock()
 	defer seg.Unlock()
 

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -115,63 +115,63 @@ type SQLData struct {
 }
 
 // DownstreamHeader returns a header for passing to downstream calls.
-func (s *Segment) DownstreamHeader() *header.Header {
-	r := s.ParentSegment.IncomingHeader
+func (seg *Segment) DownstreamHeader() *header.Header {
+	r := seg.ParentSegment.IncomingHeader
 	if r == nil {
 		r = &header.Header{
-			TraceID: s.ParentSegment.TraceID,
+			TraceID: seg.ParentSegment.TraceID,
 		}
 	}
 	if r.TraceID == "" {
-		r.TraceID = s.ParentSegment.TraceID
+		r.TraceID = seg.ParentSegment.TraceID
 	}
-	if s.ParentSegment.Sampled {
+	if seg.ParentSegment.Sampled {
 		r.SamplingDecision = header.Sampled
 	} else {
 		r.SamplingDecision = header.NotSampled
 	}
-	r.ParentID = s.ID
+	r.ParentID = seg.ID
 	return r
 }
 
 // GetCause returns value of Cause.
-func (s *Segment) GetCause() *CauseData {
-	if s.Cause == nil {
-		s.Cause = &CauseData{}
+func (seg *Segment) GetCause() *CauseData {
+	if seg.Cause == nil {
+		seg.Cause = &CauseData{}
 	}
-	return s.Cause
+	return seg.Cause
 }
 
 // GetHTTP returns value of HTTP.
-func (s *Segment) GetHTTP() *HTTPData {
-	if s.HTTP == nil {
-		s.HTTP = &HTTPData{}
+func (seg *Segment) GetHTTP() *HTTPData {
+	if seg.HTTP == nil {
+		seg.HTTP = &HTTPData{}
 	}
-	return s.HTTP
+	return seg.HTTP
 }
 
 // GetAWS returns value of AWS.
-func (s *Segment) GetAWS() map[string]interface{} {
-	if s.AWS == nil {
-		s.AWS = make(map[string]interface{})
+func (seg *Segment) GetAWS() map[string]interface{} {
+	if seg.AWS == nil {
+		seg.AWS = make(map[string]interface{})
 	}
-	return s.AWS
+	return seg.AWS
 }
 
 // GetService returns value of Service.
-func (s *Segment) GetService() *ServiceData {
-	if s.Service == nil {
-		s.Service = &ServiceData{}
+func (seg *Segment) GetService() *ServiceData {
+	if seg.Service == nil {
+		seg.Service = &ServiceData{}
 	}
-	return s.Service
+	return seg.Service
 }
 
 // GetSQL returns value of SQL.
-func (s *Segment) GetSQL() *SQLData {
-	if s.SQL == nil {
-		s.SQL = &SQLData{}
+func (seg *Segment) GetSQL() *SQLData {
+	if seg.SQL == nil {
+		seg.SQL = &SQLData{}
 	}
-	return s.SQL
+	return seg.SQL
 }
 
 // GetRequest returns value of RequestData.

--- a/xray/sql_test.go
+++ b/xray/sql_test.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"testing"
 
-	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/suite"
 )
 


### PR DESCRIPTION
Hi all,

Thank you for releasing the SDK.

I've made a few changes here and there, and I'm happy to do discuss them.

There's a breaking change as well, renaming ` HttpSubsegments  ` to ` HTTPSubsegments ` in order to confirm with the ` golint ` initialism.

I plan to have further changes as well.

Refactor out as much as possible of the package level variables as well as the calls to ` os.Getenv() `, especially in the ` xray/handler.go ` file.

A final thing that I would love to see changed would be moving everything from ` github.com/aws/aws-xray-sdk-go/xray ` to ` github.com/aws/aws-xray-sdk-go ` as the package can still be named ` xray ` but it drops the extra level of indirection, which doesn't seem to be needed as in this case.

Please let me know how to best make sure that these changes get merged in before 1.0 release.

Looking forward for your reply.