### PR TITLE
Adds NewHTTPSubsegments

### DIFF
--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -25,6 +25,12 @@ type HTTPSubsegments struct {
 	responseCtx context.Context
 }
 
+// NewHTTPSubsegments creates a new HTTPSubsegments to use in
+// httptrace.ClientTrace functions
+func NewHTTPSubsegments(opCtx context.Context) *HTTPSubsegments {
+	return &HTTPSubsegments{opCtx: opCtx}
+}
+
 // GetConn begins a connect subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) GetConn(hostPort string) {
@@ -166,9 +172,7 @@ func NewClientTrace(opCtx context.Context) (ct *ClientTrace, err error) {
 		return nil, errors.New("opCtx must be non-nil")
 	}
 
-	segs := &HTTPSubsegments{
-		opCtx: opCtx,
-	}
+	segs := NewHTTPSubsegments(opCtx)
 
 	return &ClientTrace{
 		subsegments: segs,


### PR DESCRIPTION
It's currently impossible to use a custom `httptrace.ClientTrace` with `*xray.HTTPSubsegments` because opCtx is not exported.

This PR adds a `func NewHTTPSubsegments(opCtx context.Context) *HTTPSubsegments` to allow people with already existing `httptrace.ClientTrace` to plug in AWS X-Ray.