### PR TITLE
Use `req.URL.Host` for a segment name if `req.Host` is not defined

### DIFF
--- a/xray/client.go
+++ b/xray/client.go
@@ -48,7 +48,11 @@ type roundtripper struct {
 // RoundTrip wraps a single HTTP transaction and add corresponding information into a subsegment.
 func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	var resp *http.Response
-	err := Capture(r.Context(), r.Host, func(ctx context.Context) error {
+	host := r.Host
+	if host == "" {
+		host = r.URL.Host
+	}
+	err := Capture(r.Context(), host, func(ctx context.Context) error {
 		var err error
 		seg := GetSegment(ctx)
 		if seg == nil {


### PR DESCRIPTION
It is not difficult to set a request host normally. But in some cases it is VERY difficult. When I want to use OpenAPI & go-swagger to generate source code for instance, http.Request will be created inside the library and the host is not configured. As a result, x-ray daemon would NOT send the request to AWS because the segment name is not set properly. This PR will fix the issue by using r.URL.Host if the r.Host is not defined.