### PR TITLE
Allow nil segments to noop instead of panic

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -127,7 +127,9 @@ func NewSegmentFromHeader(ctx context.Context, name string, h *header.Header) (c
 
 // Close a segment.
 func (seg *Segment) Close(err error) {
-
+	if seg == nil {
+		return
+	}
 	seg.Lock()
 	if seg.parent != nil {
 		log.Tracef("Closing subsegment named %s", seg.Name)
@@ -147,6 +149,9 @@ func (seg *Segment) Close(err error) {
 
 // RemoveSubsegment removes a subsegment child from a segment or subsegment.
 func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
+	if seg == nil {
+		return true
+	}
 	seg.Lock()
 	defer seg.Unlock()
 
@@ -216,6 +221,9 @@ func (seg *Segment) addPlugin(metadata *plugins.PluginMetadata) {
 
 // AddAnnotation allows adding an annotation to the segment.
 func (seg *Segment) AddAnnotation(key string, value interface{}) error {
+	if seg == nil {
+		return nil
+	}
 	switch value.(type) {
 	case bool, int, uint, float32, float64, string:
 	default:
@@ -234,6 +242,9 @@ func (seg *Segment) AddAnnotation(key string, value interface{}) error {
 
 // AddMetadata allows adding metadata to the segment.
 func (seg *Segment) AddMetadata(key string, value interface{}) error {
+	if seg == nil {
+		return nil
+	}
 	seg.Lock()
 	defer seg.Unlock()
 
@@ -249,6 +260,9 @@ func (seg *Segment) AddMetadata(key string, value interface{}) error {
 
 // AddMetadataToNamespace allows adding a namespace into metadata for the segment.
 func (seg *Segment) AddMetadataToNamespace(namespace string, key string, value interface{}) error {
+	if seg == nil {
+		return nil
+	}
 	seg.Lock()
 	defer seg.Unlock()
 
@@ -264,6 +278,9 @@ func (seg *Segment) AddMetadataToNamespace(namespace string, key string, value i
 
 // AddError allows adding an error to the segment.
 func (seg *Segment) AddError(err error) error {
+	if seg == nil {
+		return nil
+	}
 	seg.Lock()
 	defer seg.Unlock()
 


### PR DESCRIPTION
I'm using X-Ray like this:

The initialization portion:

```go
// XRayMissingCtxNOOP makes the XRay configuration not panic if the XRay context is missing
type XRayMissingCtxNOOP struct{}

func (XRayMissingCtxNOOP) ContextMissing(v interface{}) {}

// in the app initialization part:
func someFunc() {
	xray.Configure(xray.Config{
		DaemonAddr:     "127.0.0.1:2000",
		LogLevel:       "warn",
		ServiceVersion: serviceVersion,
		ContextMissingStrategy: XRayMissingCtxNOOP{},
	})
}

// XRayHandler allows for the request tracing
func (a *App) XRayHandler(next http.HandlerFunc) http.HandlerFunc {
	if a.fsn != nil {
		return func(w http.ResponseWriter, r *http.Request) {
			if a.shouldTrace() {
				xray.Handler(a.fsn, http.HandlerFunc(next)).ServeHTTP(w, r)
			} else {
				next(w, r)
			}
		}
	}

	return next
}
```

The handlers all are:

```
func someHandler() {
	_, subSeg := xray.BeginSubsegment(r.Context(), "http.guaranteedSend")
	var err error
	subSeg.Close(err)
	// code...
}
```

But the problem is that whenever I don't inject the xray context in it, ` Close() ` will panic.

As such, this PR no-ops the operations that are used on segments.

If there's a better way to address this, please let me know.