### PR TITLE
Explicitly initialize plugins (fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,18 +53,22 @@ import (
   "github.com/aws/aws-xray-sdk-go/xray"
 
   // Importing the plugins enables collection of AWS resource information at runtime.
-  // Every plugin should be imported after "github.com/aws/aws-xray-sdk-go/xray" library.
-  _ "github.com/aws/aws-xray-sdk-go/plugins/ec2"
-  _ "github.com/aws/aws-xray-sdk-go/plugins/beanstalk"
-  _ "github.com/aws/aws-xray-sdk-go/plugins/ecs"
+  "github.com/aws/aws-xray-sdk-go/plugins/ec2"
+  "github.com/aws/aws-xray-sdk-go/plugins/beanstalk"
+  "github.com/aws/aws-xray-sdk-go/plugins/ecs"
 )
 
 func init() {
-  xray.Configure(xray.Config{
+	// Enable the collection of AWS resource information
+    ec2.Init()
+    beanstalk.Init()
+    ecs.Init()
+    
+    xray.Configure(xray.Config{
     DaemonAddr:       "127.0.0.1:2000", // default
     LogLevel:         "info",           // default
     ServiceVersion:   "1.2.3",
-  })
+    })
 }
 ```
 

--- a/plugins/beanstalk/beanstalk.go
+++ b/plugins/beanstalk/beanstalk.go
@@ -18,7 +18,9 @@ import (
 
 const Origin = "AWS::ElasticBeanstalk::Environment"
 
-func init() {
+// Init allows applications running inside Beanstalk to add
+// their necessary metadata to the traces they provide
+func Init() {
 	if plugins.InstancePluginMetadata != nil && plugins.InstancePluginMetadata.BeanstalkMetadata == nil {
 		addPluginMetadata(plugins.InstancePluginMetadata)
 	}

--- a/plugins/ec2/ec2.go
+++ b/plugins/ec2/ec2.go
@@ -17,7 +17,9 @@ import (
 
 const Origin = "AWS::EC2::Instance"
 
-func init() {
+// Init allows applications running inside EC2 instances to add
+// their necessary metadata to the traces they provide
+func Init() {
 	if plugins.InstancePluginMetadata != nil && plugins.InstancePluginMetadata.EC2Metadata == nil {
 		addPluginMetadata(plugins.InstancePluginMetadata)
 	}

--- a/plugins/ecs/ecs.go
+++ b/plugins/ecs/ecs.go
@@ -17,7 +17,9 @@ import (
 
 const Origin = "AWS::ECS::Container"
 
-func init() {
+// Init allows applications running inside ECS containers to add
+// their necessary metadata to the traces they provide
+func Init() {
 	if plugins.InstancePluginMetadata != nil && plugins.InstancePluginMetadata.ECSMetadata == nil {
 		addPluginMetadata(plugins.InstancePluginMetadata)
 	}


### PR DESCRIPTION
This allows a user to import plugins on local development environments which do not have access to AWS metadata without stalling the process at boot time.

Each of the three plugins will need to be imported and initialized manually.
The API will safeguard against multiple requests but it's not goroutine safe.