### PR TITLE
Default config looks at the environment variable for the daemon address

### DIFF
--- a/xray/config.go
+++ b/xray/config.go
@@ -36,11 +36,10 @@ type SDK struct {
 var globalCfg = newGlobalConfig()
 
 func newGlobalConfig() *globalConfig {
+	ret := &globalConfig{}
 
-	ret := &globalConfig{
-		logLevel:  log.InfoLvl,
-		logFormat: "%Date(2006-01-02T15:04:05Z07:00) [%Level] %Msg%n",
-	}
+	// Set the logging configuration to the defaults
+	ret.logLevel, ret.logFormat = loadLogConfig("", "")
 
 	// Try to get the X-Ray daemon address from an environment variable
 	if envDaemonAddr := os.Getenv("AWS_XRAY_DAEMON_ADDRESS"); envDaemonAddr != "" {
@@ -157,7 +156,6 @@ func ContextWithConfig(ctx context.Context, c Config) (context.Context, error) {
 
 // Configure overrides default configuration options with customer-defined values.
 func Configure(c Config) error {
-
 	globalCfg.Lock()
 	defer globalCfg.Unlock()
 

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -98,7 +98,7 @@ func ResetConfig() {
 	})
 }
 
-func TestEnvironmentConfigureParameters(t *testing.T) {
+func TestEnvironmentDaemonAddress(t *testing.T) {
 
 	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "192.168.2.100:2000")
 	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
@@ -107,6 +107,15 @@ func TestEnvironmentConfigureParameters(t *testing.T) {
 
 	daemonAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 2, 100), Port: 2000}
 	assert.Equal(t, daemonAddr, cfg.daemonAddr)
+
+}
+
+func TestInvalidEnvironmentDaemonAddress(t *testing.T) {
+
+	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "This is not a valid address")
+	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
+
+	assert.Panics(t, func() { _ = newGlobalConfig() })
 
 }
 

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -98,6 +98,18 @@ func ResetConfig() {
 	})
 }
 
+func TestEnvironmentConfigureParameters(t *testing.T) {
+
+	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "192.168.2.100:2000")
+	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
+
+	cfg := newGlobalConfig()
+
+	daemonAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 2, 100), Port: 2000}
+	assert.Equal(t, daemonAddr, cfg.daemonAddr)
+
+}
+
 func TestDefaultConfigureParameters(t *testing.T) {
 	daemonAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2000}
 	logLevel := "info"

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -99,7 +99,6 @@ func ResetConfig() {
 }
 
 func TestEnvironmentDaemonAddress(t *testing.T) {
-
 	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "192.168.2.100:2000")
 	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
 
@@ -107,16 +106,13 @@ func TestEnvironmentDaemonAddress(t *testing.T) {
 
 	daemonAddr := &net.UDPAddr{IP: net.IPv4(192, 168, 2, 100), Port: 2000}
 	assert.Equal(t, daemonAddr, cfg.daemonAddr)
-
 }
 
 func TestInvalidEnvironmentDaemonAddress(t *testing.T) {
-
 	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "This is not a valid address")
 	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
 
 	assert.Panics(t, func() { _ = newGlobalConfig() })
-
 }
 
 func TestDefaultConfigureParameters(t *testing.T) {


### PR DESCRIPTION
Hi,

This change makes the SDK's default configuration try to get the daemon address from the environment. It should revert to the old default (127.0.0.1:2000) if the environment variable is missing or if it is malformed.

Let me know if this needs some revision before you merge.

Thanks!