### PR TITLE
Fix panic in xRayBeforeValidateHandler

### DIFF
--- a/xray/aws.go
+++ b/xray/aws.go
@@ -53,6 +53,9 @@ var xRayBeforeValidateHandler = request.NamedHandler{
 	Name: "XRayBeforeValidateHandler",
 	Fn: func(r *request.Request) {
 		ctx, opseg := BeginSubsegment(r.HTTPRequest.Context(), r.ClientInfo.ServiceName)
+		if opseg == nil {
+			return
+		}
 		opseg.Namespace = "aws"
 		marshalctx, _ := BeginSubsegment(ctx, "marshal")
 

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -169,7 +169,7 @@ func BeginSubsegment(ctx context.Context, name string) (context.Context, *Segmen
 			} else {
 				globalCfg.ContextMissingStrategy().ContextMissing(failedMessage)
 			}
-			return nil, nil
+			return ctx, nil
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-go/issues/50

*Description of changes:*
Fix panic in xRayBeforeValidateHandler

* Need to check for opseg == nil
* This causes a panic if the context does not contain an Xray header
* Return callers ctx instead of nil
* We should never be returning a nil context


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
