### PR TITLE
Add timing subsegment for request headers to tracer

### DIFF
--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -19,13 +19,14 @@ import (
 
 // HTTPSubsegments is a set of context in different HTTP operation.
 type HTTPSubsegments struct {
-	opCtx       context.Context
-	connCtx     context.Context
-	dnsCtx      context.Context
-	connectCtx  context.Context
-	tlsCtx      context.Context
-	reqCtx      context.Context
-	responseCtx context.Context
+	opCtx         context.Context
+	connCtx       context.Context
+	dnsCtx        context.Context
+	connectCtx    context.Context
+	tlsCtx        context.Context
+	reqCtx        context.Context
+	reqHeadersCtx context.Context
+	responseCtx   context.Context
 }
 
 // NewHTTPSubsegments creates a new HTTPSubsegments to use in
@@ -138,8 +139,17 @@ func (xt *HTTPSubsegments) GotConn(info *httptrace.GotConnInfo, err error) {
 
 		if err == nil {
 			xt.reqCtx, _ = BeginSubsegment(xt.opCtx, "request")
+			xt.reqHeadersCtx, _ = BeginSubsegment(xt.reqCtx, "request-headers")
 		}
 
+	}
+}
+
+// WroteHeaders closes the request-headers subsegment if the HTTP operation
+// subsegment is still in progress.
+func (xt *HTTPSubsegments) WroteHeaders() {
+	if xt.reqHeadersCtx != nil && GetSegment(xt.opCtx).InProgress {
+		GetSegment(xt.reqHeadersCtx).Close(nil)
 	}
 }
 
@@ -204,6 +214,9 @@ func NewClientTrace(opCtx context.Context) (ct *ClientTrace, err error) {
 			},
 			GotConn: func(info httptrace.GotConnInfo) {
 				segs.GotConn(&info, nil)
+			},
+			WroteHeaders: func() {
+				segs.WroteHeaders()
 			},
 			WroteRequest: func(info httptrace.WroteRequestInfo) {
 				segs.WroteRequest(info)

--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -148,7 +148,7 @@ func (xt *HTTPSubsegments) GotConn(info *httptrace.GotConnInfo, err error) {
 // WroteHeaders closes the request-headers subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) WroteHeaders() {
-	if xt.reqHeadersCtx != nil && GetSegment(xt.opCtx).InProgress {
+	if xt.reqHeadersCtx != nil && GetSegment(xt.opCtx).safeInProgress {
 		GetSegment(xt.reqHeadersCtx).Close(nil)
 	}
 }

--- a/xray/httptrace_go17.go
+++ b/xray/httptrace_go17.go
@@ -122,7 +122,7 @@ func (xt *HTTPSubsegments) GotConn(info *httptrace.GotConnInfo, err error) {
 // WroteHeaders closes the request-headers subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) WroteHeaders() {
-	if xt.reqHeadersCtx != nil && GetSegment(xt.opCtx).InProgress {
+	if xt.reqHeadersCtx != nil && GetSegment(xt.opCtx).safeInProgress {
 		GetSegment(xt.reqHeadersCtx).Close(nil)
 	}
 }


### PR DESCRIPTION
* Includes the WroteHeaders() event
* This event fires after the Transport has written the request headers
* I have included it as a subsegment of the request subsegment


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
