### PR TITLE
Update readme to reflect Lambda supporting version

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ func main() {
 
 **Lambda**
 
+```
+For Lambda support use version v1.0.0-rc.1 and higher
+```
+
 Use AWS X-Ray SDK for Go to generate custom subsegments inside AWS Lambda handler function.
 
 ```go


### PR DESCRIPTION
In https://github.com/aws/aws-xray-sdk-go/issues/50 said what AWS Lambda support is avaialble starting from v1.0.0-rc.1 and higher. If you are using `dep`, then by default it will select version 0.9.4 without Lambda support.

This change will help people to properly start using SDK for Lambda


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
