### PR TITLE
fix httptrace datarace

### DIFF
--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -12,9 +12,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -189,4 +191,37 @@ func TestBadRoundTrip(t *testing.T) {
 	subseg := &Segment{}
 	assert.NoError(t, json.Unmarshal(s.Subsegments[0], &subseg))
 	assert.Equal(t, fmt.Sprintf("%v", err), subseg.Cause.Exceptions[0].Message)
+}
+
+func TestRoundTrip_reuse_datarace(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := []byte(`200 - Nothing to see`)
+		w.WriteHeader(http.StatusOK)
+		w.Write(b)
+	}))
+
+	defer ts.Close()
+
+	wg := sync.WaitGroup{}
+	n := 30
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			reader := strings.NewReader("")
+			ctx, root := BeginSegment(context.Background(), "Test")
+			req := httptest.NewRequest("GET", strings.Replace(ts.URL, "127.0.0.1", "localhost", -1), reader)
+			req = req.WithContext(ctx)
+			res, err := rt.RoundTrip(req)
+			ioutil.ReadAll(res.Body)
+			res.Body.Close() // make net/http/transport.go connection reuse
+			root.Close(nil)
+			assert.NoError(t, err)
+		}()
+	}
+	for i := 0; i < n; i++ {
+		_, e := TestDaemon.Recv()
+		assert.NoError(t, e)
+	}
+	wg.Wait()
 }

--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -45,7 +45,7 @@ func (xt *HTTPSubsegments) GetConn(hostPort string) {
 // DNSStart begins a dns subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) DNSStart(info httptrace.DNSStartInfo) {
-	if GetSegment(xt.opCtx).InProgress {
+	if GetSegment(xt.opCtx).safeInProgress() {
 		xt.dnsCtx, _ = BeginSubsegment(xt.connCtx, "dns")
 	}
 }
@@ -56,7 +56,7 @@ func (xt *HTTPSubsegments) DNSStart(info httptrace.DNSStartInfo) {
 // and whether or not the call was coalesced is added as
 // metadata to the dns subsegment.
 func (xt *HTTPSubsegments) DNSDone(info httptrace.DNSDoneInfo) {
-	if xt.dnsCtx != nil && GetSegment(xt.opCtx).InProgress {
+	if xt.dnsCtx != nil && GetSegment(xt.opCtx).safeInProgress() {
 		metadata := make(map[string]interface{})
 		metadata["addresses"] = info.Addrs
 		metadata["coalesced"] = info.Coalesced
@@ -69,7 +69,7 @@ func (xt *HTTPSubsegments) DNSDone(info httptrace.DNSDoneInfo) {
 // ConnectStart begins a dial subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) ConnectStart(network, addr string) {
-	if GetSegment(xt.opCtx).InProgress {
+	if GetSegment(xt.opCtx).safeInProgress() {
 		xt.connectCtx, _ = BeginSubsegment(xt.connCtx, "dial")
 	}
 }
@@ -79,7 +79,7 @@ func (xt *HTTPSubsegments) ConnectStart(network, addr string) {
 // (if any). Information about the network over which the dial
 // was made is added as metadata to the subsegment.
 func (xt *HTTPSubsegments) ConnectDone(network, addr string, err error) {
-	if xt.connectCtx != nil && GetSegment(xt.opCtx).InProgress {
+	if xt.connectCtx != nil && GetSegment(xt.opCtx).safeInProgress() {
 		metadata := make(map[string]interface{})
 		metadata["network"] = network
 
@@ -91,7 +91,7 @@ func (xt *HTTPSubsegments) ConnectDone(network, addr string, err error) {
 // TLSHandshakeStart begins a tls subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) TLSHandshakeStart() {
-	if GetSegment(xt.opCtx).InProgress {
+	if GetSegment(xt.opCtx).safeInProgress() {
 		xt.tlsCtx, _ = BeginSubsegment(xt.connCtx, "tls")
 	}
 }
@@ -101,7 +101,7 @@ func (xt *HTTPSubsegments) TLSHandshakeStart() {
 // error value(if any). Information about the tls connection
 // is added as metadata to the subsegment.
 func (xt *HTTPSubsegments) TLSHandshakeDone(connState tls.ConnectionState, err error) {
-	if xt.tlsCtx != nil && GetSegment(xt.opCtx).InProgress {
+	if xt.tlsCtx != nil && GetSegment(xt.opCtx).safeInProgress() {
 		metadata := make(map[string]interface{})
 		metadata["did_resume"] = connState.DidResume
 		metadata["negotiated_protocol"] = connState.NegotiatedProtocol

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -314,6 +314,13 @@ func (seg *Segment) safeFlush() {
 	seg.flush()
 }
 
+func (seg *Segment) safeInProgress() bool {
+	seg.Lock()
+	b := seg.InProgress
+	seg.Unlock()
+	return b
+}
+
 func (seg *Segment) root() *Segment {
 	if seg.parent == nil {
 		return seg


### PR DESCRIPTION
There is a data-race condition in `xray/httptrace.go`, because go's http client reuses idle connections aggressively.
`DefaultTransport.getConn` https://golang.org/src/net/http/transport.go#L990 dials new connection and reuses `idleConn` in parallel.

Without this change, the test will cause the below:

```
WARNING: DATA RACE
Write at 0x00c42051a7f8 by goroutine 129:
  github.com/aws/aws-xray-sdk-go/xray.(*Segment).Close()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/segment.go:237 +0x248
  github.com/aws/aws-xray-sdk-go/xray.Capture.func1()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/capture.go:23 +0x87
  github.com/aws/aws-xray-sdk-go/xray.Capture()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/capture.go:48 +0x15a
  github.com/aws/aws-xray-sdk-go/xray.(*roundtripper).RoundTrip()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/client.go:64 +0x1eb
  github.com/aws/aws-xray-sdk-go/xray.TestRoundTrip_reuse_datarace.func2()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/client_test.go:215 +0x244

Previous read at 0x00c42051a7f8 by goroutine 32:
  github.com/aws/aws-xray-sdk-go/xray.(*HTTPSubsegments).ConnectStart()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/httptrace.go:72 +0x6d
  github.com/aws/aws-xray-sdk-go/xray.NewClientTrace.func4()
      /home/t-yuki/go/src/github.com/aws/aws-xray-sdk-go/xray/httptrace.go:194 +0x69
  net.dialSingle()
      /home/t-yuki/go/tools/go/src/net/dial.go:537 +0xb43
  net.dialSerial()
      /home/t-yuki/go/tools/go/src/net/dial.go:515 +0x251
  net.(*Dialer).DialContext()
      /home/t-yuki/go/tools/go/src/net/dial.go:397 +0x8f1
  net.(*Dialer).DialContext-fm()
      /home/t-yuki/go/tools/go/src/net/http/transport.go:46 +0x99
  net/http.(*Transport).dial()
      /home/t-yuki/go/tools/go/src/net/http/transport.go:898 +0x322
  net/http.(*Transport).dialConn()
      /home/t-yuki/go/tools/go/src/net/http/transport.go:1143 +0x4ee
  net/http.(*Transport).getConn.func4()
      /home/t-yuki/go/tools/go/src/net/http/transport.go:957 +0x9f
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
