### PR TITLE
samplingRule should be an exported type

### DIFF
--- a/strategy/sampling/centralized_sampling_rule_manifest.go
+++ b/strategy/sampling/centralized_sampling_rule_manifest.go
@@ -92,7 +92,7 @@ func (m *CentralizedManifest) createUserRule(svcRule *xraySvc.SamplingRule) *Cen
 	clock := &utils.DefaultClock{}
 	rand := &utils.DefaultRand{}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		ServiceName: *svcRule.ServiceName,
 		HTTPMethod:  *svcRule.HTTPMethod,
 		URLPath:     *svcRule.URLPath,
@@ -114,7 +114,7 @@ func (m *CentralizedManifest) createUserRule(svcRule *xraySvc.SamplingRule) *Cen
 		ruleName:     *svcRule.RuleName,
 		priority:     *svcRule.Priority,
 		reservoir:    cr,
-		samplingRule: sr,
+		SamplingRule: sr,
 		serviceType:  *svcRule.ServiceType,
 		resourceARN:  *svcRule.ResourceARN,
 		attributes:   svcRule.Attributes,
@@ -145,7 +145,7 @@ func (m *CentralizedManifest) createUserRule(svcRule *xraySvc.SamplingRule) *Cen
 func (m *CentralizedManifest) updateUserRule(r *CentralizedRule, svcRule *xraySvc.SamplingRule) {
 	// Preemptively dereference xraySvc.SamplingRule fields and panic early on nil pointers.
 	// A panic in the middle of an update may leave the rule in an inconsistent state.
-	s := &samplingRule{
+	s := &SamplingRule{
 		ServiceName: *svcRule.ServiceName,
 		HTTPMethod:  *svcRule.HTTPMethod,
 		URLPath:     *svcRule.URLPath,
@@ -159,7 +159,7 @@ func (m *CentralizedManifest) updateUserRule(r *CentralizedRule, svcRule *xraySv
 	r.Lock()
 	defer r.Unlock()
 
-	r.samplingRule = s
+	r.SamplingRule = s
 	r.priority = p
 	r.reservoir.capacity = c
 	r.serviceType = *svcRule.ServiceType
@@ -174,7 +174,7 @@ func (m *CentralizedManifest) createDefaultRule(svcRule *xraySvc.SamplingRule) *
 	clock := &utils.DefaultClock{}
 	rand := &utils.DefaultRand{}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		FixedTarget: *svcRule.ReservoirSize,
 		Rate:        *svcRule.FixedRate,
 	}
@@ -191,7 +191,7 @@ func (m *CentralizedManifest) createDefaultRule(svcRule *xraySvc.SamplingRule) *
 	csr := &CentralizedRule{
 		ruleName:     *svcRule.RuleName,
 		reservoir:    cr,
-		samplingRule: sr,
+		SamplingRule: sr,
 		clock:        clock,
 		rand:         rand,
 	}
@@ -221,7 +221,7 @@ func (m *CentralizedManifest) updateDefaultRule(svcRule *xraySvc.SamplingRule) {
 
 	// Preemptively dereference xraySvc.SamplingRule fields and panic early on nil pointers.
 	// A panic in the middle of an update may leave the rule in an inconsistent state.
-	s := &samplingRule{
+	s := &SamplingRule{
 		FixedTarget: *svcRule.ReservoirSize,
 		Rate:        *svcRule.FixedRate,
 	}
@@ -231,7 +231,7 @@ func (m *CentralizedManifest) updateDefaultRule(svcRule *xraySvc.SamplingRule) {
 	r.Lock()
 	defer r.Unlock()
 
-	r.samplingRule = s
+	r.SamplingRule = s
 	r.reservoir.capacity = c
 }
 

--- a/strategy/sampling/centralized_sampling_rule_manifest_test.go
+++ b/strategy/sampling/centralized_sampling_rule_manifest_test.go
@@ -69,7 +69,7 @@ func TestCreateUserRule(t *testing.T) {
 	clock := &utils.DefaultClock{}
 	rand := &utils.DefaultRand{}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		ServiceName: serviceName,
 		HTTPMethod:  httpMethod,
 		URLPath:     urlPath,
@@ -89,7 +89,7 @@ func TestCreateUserRule(t *testing.T) {
 		reservoir:    cr,
 		ruleName:     ruleName,
 		priority:     priority,
-		samplingRule: sr,
+		SamplingRule: sr,
 		clock:        clock,
 		rand:         rand,
 		serviceType:  serviceTye,
@@ -131,7 +131,7 @@ func TestCreateDefaultRule(t *testing.T) {
 	clock := &utils.DefaultClock{}
 	rand := &utils.DefaultRand{}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		FixedTarget: reservoirSize,
 		Rate:        fixedRate,
 	}
@@ -146,7 +146,7 @@ func TestCreateDefaultRule(t *testing.T) {
 	exp := &CentralizedRule{
 		reservoir:    cr,
 		ruleName:     ruleName,
-		samplingRule: sr,
+		SamplingRule: sr,
 		clock:        clock,
 		rand:         rand,
 	}
@@ -166,7 +166,7 @@ func TestUpdateDefaultRule(t *testing.T) {
 	// Original default sampling rule
 	r := &CentralizedRule{
 		ruleName: "Default",
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			FixedTarget: 10,
 			Rate:        0.05,
 		},
@@ -194,7 +194,7 @@ func TestUpdateDefaultRule(t *testing.T) {
 	}
 
 	// Expected centralized sampling rule
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		FixedTarget: reservoirSize,
 		Rate:        fixedRate,
 	}
@@ -208,7 +208,7 @@ func TestUpdateDefaultRule(t *testing.T) {
 	exp := &CentralizedRule{
 		reservoir:    cr,
 		ruleName:     ruleName,
-		samplingRule: sr,
+		SamplingRule: sr,
 		clock:        clock,
 		rand:         rand,
 	}
@@ -292,7 +292,7 @@ func TestUpdateUserRule(t *testing.T) {
 	r1 := &CentralizedRule{
 		ruleName: "r1",
 		priority: 5,
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "*.foo.com",
 			HTTPMethod:  "GET",
 			URLPath:     "/resource/*",
@@ -344,7 +344,7 @@ func TestUpdateUserRule(t *testing.T) {
 	}
 
 	// Expected updated centralized sampling rule
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		ServiceName: serviceName,
 		HTTPMethod:  httpMethod,
 		URLPath:     urlPath,
@@ -363,7 +363,7 @@ func TestUpdateUserRule(t *testing.T) {
 		reservoir:    cr,
 		ruleName:     ruleName,
 		priority:     priority,
-		samplingRule: sr,
+		SamplingRule: sr,
 		resourceARN:  resARN,
 		serviceType:  serviceTye,
 		attributes:   attributes,

--- a/strategy/sampling/centralized_test.go
+++ b/strategy/sampling/centralized_test.go
@@ -55,8 +55,8 @@ func (p *mockProxy) GetSamplingTargets(s []*xraySvc.SamplingStatisticsDocument) 
 	return &copy, nil
 }
 
-func getSamplingRule(host string, method string, url string, serviceName string, rate float64, ft int) *samplingRule {
-	return &samplingRule{
+func getSamplingRule(host string, method string, url string, serviceName string, rate float64, ft int) *SamplingRule {
+	return &SamplingRule{
 		Host:        host,
 		HTTPMethod:  method,
 		URLPath:     url,
@@ -102,7 +102,7 @@ func TestShouldTracePositive1(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule(host1, method1, url1, serviceName1, 0, 0),
+		SamplingRule: getSamplingRule(host1, method1, url1, serviceName1, 0, 0),
 		serviceType:  servType1,
 		clock:        clock,
 		rand:         rand,
@@ -124,7 +124,7 @@ func TestShouldTracePositive1(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule(host2, method2, url2, serviceName2, 0, 0),
+		SamplingRule: getSamplingRule(host2, method2, url2, serviceName2, 0, 0),
 		clock:        clock,
 		rand:         rand,
 	}
@@ -197,7 +197,7 @@ func TestShouldTracePositive2(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule(host1, method1, url1, serviceName1, 0, 0),
+		SamplingRule: getSamplingRule(host1, method1, url1, serviceName1, 0, 0),
 		serviceType:  servType1,
 		clock:        clock,
 		rand:         rand,
@@ -219,7 +219,7 @@ func TestShouldTracePositive2(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule(host2, method2, url2, serviceName2, 0, 0),
+		SamplingRule: getSamplingRule(host2, method2, url2, serviceName2, 0, 0),
 		clock:        clock,
 		rand:         rand,
 	}
@@ -278,7 +278,7 @@ func TestShouldTraceDefaultPositive(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule("www.foo.com", "POST", "/resource/bar", "", 0, 0),
+		SamplingRule: getSamplingRule("www.foo.com", "POST", "/resource/bar", "", 0, 0),
 		clock:        clock,
 		rand:         rand,
 	}
@@ -363,7 +363,7 @@ func TestShouldTraceExpiredManifest(t *testing.T) {
 				currentEpoch: 1500000000,
 			},
 		},
-		samplingRule: getSamplingRule("www.foo.com", "POST", "/resource/bar", "", 0, 0),
+		SamplingRule: getSamplingRule("www.foo.com", "POST", "/resource/bar", "", 0, 0),
 		clock:        clock,
 		rand:         rand,
 	}
@@ -391,7 +391,7 @@ func TestShouldTraceExpiredManifest(t *testing.T) {
 				currentEpoch: int64(1500003601),
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			FixedTarget: int64(10),
 			Rate:        float64(0.05),
 		},
@@ -627,7 +627,7 @@ func TestUpdateTarget(t *testing.T) {
 	// Sampling rule about to be updated with new target
 	csr := &CentralizedRule{
 		ruleName: "r1",
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Rate: 0.10,
 		},
 		reservoir: &CentralizedReservoir{
@@ -664,7 +664,7 @@ func TestUpdateTarget(t *testing.T) {
 	// Updated sampling rule
 	exp := &CentralizedRule{
 		ruleName: "r1",
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Rate: 0.05,
 		},
 		reservoir: &CentralizedReservoir{
@@ -730,7 +730,7 @@ func TestUpdateTargetPanicRecovery(t *testing.T) {
 	// Sampling rule about to be updated with new target
 	csr := &CentralizedRule{
 		ruleName: "r1",
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Rate: 0.10,
 		},
 		reservoir: &CentralizedReservoir{
@@ -765,7 +765,7 @@ func TestUpdateTargetPanicRecovery(t *testing.T) {
 	// Unchanged sampling rule
 	exp := &CentralizedRule{
 		ruleName: "r1",
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Rate: 0.10,
 		},
 		reservoir: &CentralizedReservoir{
@@ -798,7 +798,7 @@ func TestRefreshManifestRuleAddition(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{},
+		SamplingRule: &SamplingRule{},
 		priority:     4,
 		resourceARN:  resourceARN,
 	}
@@ -812,7 +812,7 @@ func TestRefreshManifestRuleAddition(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -943,7 +943,7 @@ func TestRefreshManifestRuleAddition(t *testing.T) {
 			},
 			interval: 10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.fizz.com",
 			HTTPMethod:  "PUT",
 			URLPath:     "/resource/fizz",
@@ -986,7 +986,7 @@ func TestRefreshManifestRuleAdditionInvalidRule1(t *testing.T) { // ResourceARN 
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{},
+		SamplingRule: &SamplingRule{},
 		priority:     4,
 		resourceARN:  resourceARN,
 	}
@@ -1066,7 +1066,7 @@ func TestRefreshManifestRuleAdditionInvalidRule2(t *testing.T) { // non nil Attr
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{},
+		SamplingRule: &SamplingRule{},
 		priority:     4,
 		resourceARN:  resourceARN,
 	}
@@ -1147,7 +1147,7 @@ func TestRefreshManifestRuleAdditionInvalidRule3(t *testing.T) { // 1 valid and 
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{},
+		SamplingRule: &SamplingRule{},
 		priority:     4,
 		resourceARN:  resourceARN,
 	}
@@ -1160,7 +1160,7 @@ func TestRefreshManifestRuleAdditionInvalidRule3(t *testing.T) { // 1 valid and 
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{},
+		SamplingRule: &SamplingRule{},
 		priority:     4,
 		resourceARN:  resourceARN,
 	}
@@ -1260,7 +1260,7 @@ func TestRefreshManifestRuleRemoval(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -1280,7 +1280,7 @@ func TestRefreshManifestRuleRemoval(t *testing.T) {
 				capacity: 60,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.fizz.com",
 			HTTPMethod:  "PUT",
 			URLPath:     "/resource/fizz",
@@ -1300,7 +1300,7 @@ func TestRefreshManifestRuleRemoval(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -1429,7 +1429,7 @@ func TestRefreshManifestInvalidRuleUpdate(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -1450,7 +1450,7 @@ func TestRefreshManifestInvalidRuleUpdate(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -1574,7 +1574,7 @@ func TestRefreshManifestInvalidNewRule(t *testing.T) {
 				capacity: 40,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -1595,7 +1595,7 @@ func TestRefreshManifestInvalidNewRule(t *testing.T) {
 				capacity: 50,
 			},
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -1834,7 +1834,7 @@ func TestRefreshTargets(t *testing.T) {
 			refreshedAt: 1499999990,
 			interval:    10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -1861,7 +1861,7 @@ func TestRefreshTargets(t *testing.T) {
 			refreshedAt: 1499999990,
 			interval:    10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -1944,7 +1944,7 @@ func TestRefreshTargets(t *testing.T) {
 			expiresAt: 1500000060,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -1968,7 +1968,7 @@ func TestRefreshTargets(t *testing.T) {
 			expiresAt: 1500000060,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2012,7 +2012,7 @@ func TestRefreshTargetsVariableIntervals(t *testing.T) {
 			refreshedAt: 1499999990,
 			interval:    20,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -2039,7 +2039,7 @@ func TestRefreshTargetsVariableIntervals(t *testing.T) {
 			refreshedAt: 1499999990,
 			interval:    30,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2131,7 +2131,7 @@ func TestRefreshTargetsVariableIntervals(t *testing.T) {
 			expiresAt: 1500000060,
 			interval:  20,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -2158,7 +2158,7 @@ func TestRefreshTargetsVariableIntervals(t *testing.T) {
 			refreshedAt: 1499999990,
 			interval:    30,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2191,7 +2191,7 @@ func TestRefreshTargetsVariableIntervals(t *testing.T) {
 			expiresAt: 1500000060,
 			interval:  30,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2237,7 +2237,7 @@ func TestRefreshTargetsInvalidTarget(t *testing.T) {
 			interval:  10,
 			expiresAt: 1500000050,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -2263,7 +2263,7 @@ func TestRefreshTargetsInvalidTarget(t *testing.T) {
 			expiresAt: 1500000050,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2344,7 +2344,7 @@ func TestRefreshTargetsInvalidTarget(t *testing.T) {
 			expiresAt: 1500000050,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.foo.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/bar",
@@ -2368,7 +2368,7 @@ func TestRefreshTargetsInvalidTarget(t *testing.T) {
 			expiresAt: 1500000060,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2415,7 +2415,7 @@ func TestRefreshTargetsOutdatedManifest(t *testing.T) {
 			expiresAt: 1500000050,
 			interval:  10,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			ServiceName: "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",
@@ -2543,7 +2543,7 @@ func TestRefreshTargetsProxyError(t *testing.T) {
 			},
 			expiresAt: 1500000050,
 		},
-		samplingRule: &samplingRule{
+		SamplingRule: &SamplingRule{
 			Host:        "www.bar.com",
 			HTTPMethod:  "POST",
 			URLPath:     "/resource/foo",

--- a/strategy/sampling/sampling_rule.go
+++ b/strategy/sampling/sampling_rule.go
@@ -18,8 +18,8 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// samplingRule is the base set of properties that define a sampling rule.
-type samplingRule struct {
+// SamplingRule is the base set of properties that define a sampling rule.
+type SamplingRule struct {
 	ServiceName string  `json:"service_name"`
 	Host        string  `json:"host"`
 	HTTPMethod  string  `json:"http_method"`
@@ -30,7 +30,7 @@ type samplingRule struct {
 
 // AppliesTo returns true if the sampling rule matches against given parameters. False Otherwise.
 // Assumes lock is already held, if required.
-func (r *samplingRule) AppliesTo(host, path, method string) bool {
+func (r *SamplingRule) AppliesTo(host, path, method string) bool {
 	return (host == "" || pattern.WildcardMatchCaseInsensitive(r.Host, host)) &&
 		(path == "" || pattern.WildcardMatchCaseInsensitive(r.URLPath, path)) &&
 		(method == "" || pattern.WildcardMatchCaseInsensitive(r.HTTPMethod, method))
@@ -70,7 +70,7 @@ type CentralizedRule struct {
 	usedAt int64
 
 	// Common sampling rule properties
-	*samplingRule
+	*SamplingRule
 
 	// ServiceType for the sampling rule
 	serviceType string
@@ -198,7 +198,7 @@ type Rule struct {
 	rand utils.Rand
 
 	// Common sampling rule properties
-	*samplingRule
+	*SamplingRule
 }
 
 func (r *Rule) Sample() *Decision {

--- a/strategy/sampling/sampling_rule_test.go
+++ b/strategy/sampling/sampling_rule_test.go
@@ -66,7 +66,7 @@ func TestExpiredReservoirBernoulliSample(t *testing.T) {
 		F64: 0.05,
 	}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		Rate: 0.06,
 	}
 
@@ -84,7 +84,7 @@ func TestExpiredReservoirBernoulliSample(t *testing.T) {
 	csr := &CentralizedRule{
 		ruleName:     "r1",
 		reservoir:    cr,
-		samplingRule: sr,
+		SamplingRule: sr,
 		clock:        clock,
 		rand:         rand,
 	}
@@ -145,7 +145,7 @@ func TestBernoulliSamplePositve(t *testing.T) {
 		F64: 0.05,
 	}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		Rate: 0.06,
 	}
 
@@ -158,7 +158,7 @@ func TestBernoulliSamplePositve(t *testing.T) {
 	csr := &CentralizedRule{
 		ruleName:     "r1",
 		reservoir:    cr,
-		samplingRule: sr,
+		SamplingRule: sr,
 		rand:         rand,
 		clock:        clock,
 	}
@@ -188,7 +188,7 @@ func TestBernoulliSampleNegative(t *testing.T) {
 		F64: 0.07,
 	}
 
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		Rate: 0.06,
 	}
 
@@ -201,7 +201,7 @@ func TestBernoulliSampleNegative(t *testing.T) {
 	csr := &CentralizedRule{
 		ruleName:     "r1",
 		reservoir:    cr,
-		samplingRule: sr,
+		SamplingRule: sr,
 		rand:         rand,
 		clock:        clock,
 	}
@@ -261,7 +261,7 @@ func TestLocalBernoulliSample(t *testing.T) {
 	}
 
 	// 6% sampling rate
-	sr := &samplingRule{
+	sr := &SamplingRule{
 		Rate: 0.06,
 	}
 
@@ -273,7 +273,7 @@ func TestLocalBernoulliSample(t *testing.T) {
 	lsr := &Rule{
 		reservoir:    lr,
 		rand:         rand,
-		samplingRule: sr,
+		SamplingRule: sr,
 	}
 
 	sd := lsr.Sample()


### PR DESCRIPTION
this commit fixes a runtime panic "cannot set embedded pointer to unexported struct: sampling.samplingRule"

see https://github.com/golang/go/issues/21357

*Issue #, if available:*

*Description of changes:*
sampling.samplingRule is now an exported type. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
