### PR TITLE
Logging interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,31 @@ func init() {
 }
 ```
 
+**Logger**
+
+xray uses an interface for its logger:
+
+```go
+type Logger interface {
+  Log(level LogLevel, msg fmt.Stringer)
+}
+
+const (
+  LogLevelDebug LogLevel = iota + 1
+  LogLevelInfo
+  LogLevelWarn
+  LogLevelError
+)
+```
+
+The default logger logs to stdout at "info" and above. To change the logger, call `xray.SetLogger(myLogger)`. There is a default logger implementation that writes to an `io.Writer` from a specified minimum log level. For example, to log to stderr at "error" and above:
+
+```go
+xray.SetLogger(xraylog.NewDefaultLogger(os.Stderr, xraylog.LogLevelError))
+```
+
+Note that the `xray.Config{}` fields `LogLevel` and `LogFormat` are deprecated and no longer have any effect.
+
 ## License
 
 The AWS X-Ray SDK for Go is licensed under the Apache 2.0 License. See LICENSE and NOTICE.txt for more information.

--- a/awsplugins/beanstalk/beanstalk.go
+++ b/awsplugins/beanstalk/beanstalk.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	log "github.com/cihub/seelog"
 )
 
 const Origin = "AWS::ElasticBeanstalk::Environment"
@@ -29,14 +29,14 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 
 	rawConfig, err := ioutil.ReadFile(ebConfigPath)
 	if err != nil {
-		log.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		logger.Errorf("Unable to read Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 
 	config := &plugins.BeanstalkMetadata{}
 	err = json.Unmarshal(rawConfig, config)
 	if err != nil {
-		log.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
+		logger.Errorf("Unable to unmarshal Elastic Beanstalk configuration file %s: %v", ebConfigPath, err)
 		return
 	}
 

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -11,8 +11,8 @@ package ec2
 import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	log "github.com/cihub/seelog"
 )
 
 const Origin = "AWS::EC2::Instance"
@@ -26,13 +26,13 @@ func Init() {
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	session, e := session.NewSession()
 	if e != nil {
-		log.Errorf("Unable to create a new ec2 session: %v", e)
+		logger.Errorf("Unable to create a new ec2 session: %v", e)
 		return
 	}
 	client := ec2metadata.New(session)
 	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
-		log.Errorf("Unable to read EC2 instance metadata: %v", err)
+		logger.Errorf("Unable to read EC2 instance metadata: %v", err)
 		return
 	}
 

--- a/awsplugins/ecs/ecs.go
+++ b/awsplugins/ecs/ecs.go
@@ -11,8 +11,8 @@ package ecs
 import (
 	"os"
 
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	log "github.com/cihub/seelog"
 )
 
 const Origin = "AWS::ECS::Container"
@@ -27,7 +27,7 @@ func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
 	hostname, err := os.Hostname()
 
 	if err != nil {
-		log.Errorf("Unable to retrieve hostname from OS. %v", err)
+		logger.Errorf("Unable to retrieve hostname from OS. %v", err)
 		return
 	}
 

--- a/daemoncfg/daemon_config.go
+++ b/daemoncfg/daemon_config.go
@@ -13,8 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/cihub/seelog"
-
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/pkg/errors"
 )
 
@@ -69,7 +68,7 @@ func GetDaemonEndpointsFromString(dAddr string) (*DaemonEndpoints, error) {
 	// Try to get the X-Ray daemon address from an environment variable
 	if envDaemonAddr := os.Getenv("AWS_XRAY_DAEMON_ADDRESS"); envDaemonAddr != "" {
 		daemonAddr = envDaemonAddr
-		log.Infof("using daemon endpoints from environment variable AWS_XRAY_DAEMON_ADDRESS: %v", envDaemonAddr)
+		logger.Infof("using daemon endpoints from environment variable AWS_XRAY_DAEMON_ADDRESS: %v", envDaemonAddr)
 	} else if dAddr != "" {
 		daemonAddr = dAddr
 	}
@@ -85,12 +84,9 @@ func resolveAddress(dAddr string) (*DaemonEndpoints, error) {
 		return parseSingleForm(addr[0])
 	} else if len(addr) == 2 {
 		return parseDoubleForm(addr)
-
 	} else {
 		return nil, errors.New("invalid daemon address: " + dAddr)
 	}
-
-	return nil, nil
 }
 
 func parseDoubleForm(addr []string) (*DaemonEndpoints, error) {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,78 @@
+// Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package logger
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-xray-sdk-go/xraylog"
+)
+
+// This internal pacakge hides the actual logging functions from the user.
+
+// The Logger instance used by xray to log. Set via xray.SetLogger().
+var Logger xraylog.Logger = xraylog.NewDefaultLogger(os.Stdout, xraylog.LogLevelInfo)
+
+func Debugf(format string, args ...interface{}) {
+	Logger.Log(xraylog.LogLevelDebug, printfArgs{format, args})
+}
+
+func Debug(args ...interface{}) {
+	Logger.Log(xraylog.LogLevelDebug, printArgs(args))
+}
+
+func DebugDeferred(fn func() string) {
+	Logger.Log(xraylog.LogLevelDebug, stringerFunc(fn))
+}
+
+func Infof(format string, args ...interface{}) {
+	Logger.Log(xraylog.LogLevelInfo, printfArgs{format, args})
+}
+
+func Info(args ...interface{}) {
+	Logger.Log(xraylog.LogLevelInfo, printArgs(args))
+}
+
+func Warnf(format string, args ...interface{}) {
+	Logger.Log(xraylog.LogLevelWarn, printfArgs{format, args})
+}
+
+func Warn(args ...interface{}) {
+	Logger.Log(xraylog.LogLevelWarn, printArgs(args))
+}
+
+func Errorf(format string, args ...interface{}) {
+	Logger.Log(xraylog.LogLevelError, printfArgs{format, args})
+}
+
+func Error(args ...interface{}) {
+	Logger.Log(xraylog.LogLevelError, printArgs(args))
+}
+
+type printfArgs struct {
+	format string
+	args   []interface{}
+}
+
+func (p printfArgs) String() string {
+	return fmt.Sprintf(p.format, p.args...)
+}
+
+type printArgs []interface{}
+
+func (p printArgs) String() string {
+	return fmt.Sprint([]interface{}(p)...)
+}
+
+type stringerFunc func() string
+
+func (sf stringerFunc) String() string {
+	return sf()
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,83 @@
+// Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-xray-sdk-go/xraylog"
+)
+
+func TestLogger(t *testing.T) {
+	oldLogger := Logger
+	defer func() { Logger = oldLogger }()
+
+	var buf bytes.Buffer
+
+	// filter properly by level
+	Logger = xraylog.NewDefaultLogger(&buf, xraylog.LogLevelWarn)
+
+	Debug("debug")
+	Info("info")
+	Warn("warn")
+	Error("error")
+
+	gotLines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(gotLines) != 2 {
+		t.Fatalf("got %d lines", len(gotLines))
+	}
+
+	if !strings.Contains(gotLines[0], "[WARN] warn") {
+		t.Error("expected first line to be warn")
+	}
+
+	if !strings.Contains(gotLines[1], "[ERROR] error") {
+		t.Error("expected second line to be warn")
+	}
+}
+
+func TestDeferredDebug(t *testing.T) {
+	oldLogger := Logger
+	defer func() { Logger = oldLogger }()
+
+	var buf bytes.Buffer
+
+	Logger = xraylog.NewDefaultLogger(&buf, xraylog.LogLevelInfo)
+
+	var called bool
+	DebugDeferred(func() string {
+		called = true
+		return "deferred"
+	})
+
+	if called {
+		t.Error("deferred should not have been called")
+	}
+
+	if buf.String() != "" {
+		t.Errorf("unexpected log contents: %s", buf.String())
+	}
+
+	Logger = xraylog.NewDefaultLogger(&buf, xraylog.LogLevelDebug)
+
+	DebugDeferred(func() string {
+		called = true
+		return "deferred"
+	})
+
+	if !called {
+		t.Error("deferred should have been called")
+	}
+
+	if !strings.Contains(buf.String(), "[DEBUG] deferred") {
+		t.Errorf("expected deferred message, got %s", buf.String())
+	}
+}

--- a/strategy/ctxmissing/default_context_missing.go
+++ b/strategy/ctxmissing/default_context_missing.go
@@ -8,9 +8,7 @@
 
 package ctxmissing
 
-import (
-	log "github.com/cihub/seelog"
-)
+import "github.com/aws/aws-xray-sdk-go/internal/logger"
 
 // RuntimeErrorStrategy provides the AWS_XRAY_CONTEXT_MISSING
 // environment variable value for enabling the runtime error
@@ -50,5 +48,5 @@ func (dr *DefaultRuntimeErrorStrategy) ContextMissing(v interface{}) {
 // ContextMissing logs an error message when the
 // segment context is missing.
 func (dl *DefaultLogErrorStrategy) ContextMissing(v interface{}) {
-	log.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
+	logger.Errorf("Suppressing AWS X-Ray context missing panic: %v", v)
 }

--- a/strategy/sampling/localized.go
+++ b/strategy/sampling/localized.go
@@ -9,8 +9,8 @@
 package sampling
 
 import (
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/resources"
-	log "github.com/cihub/seelog"
 )
 
 // LocalizedStrategy makes trace sampling decisions based on
@@ -60,15 +60,15 @@ func NewLocalizedStrategyFromJSONBytes(b []byte) (*LocalizedStrategy, error) {
 // ShouldTrace consults the LocalizedStrategy's rule set to determine
 // if the given request should be traced or not.
 func (lss *LocalizedStrategy) ShouldTrace(rq *Request) *Decision {
-	log.Tracef("Determining ShouldTrace decision for:\n\thost: %s\n\tpath: %s\n\tmethod: %s", rq.Host, rq.Url, rq.Method)
+	logger.Debugf("Determining ShouldTrace decision for:\n\thost: %s\n\tpath: %s\n\tmethod: %s", rq.Host, rq.Url, rq.Method)
 	if nil != lss.manifest.Rules {
 		for _, r := range lss.manifest.Rules {
 			if r.AppliesTo(rq.Host, rq.Url, rq.Method) {
-				log.Tracef("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\thost: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.Host, r.URLPath, r.HTTPMethod)
+				logger.Debugf("Applicable rule:\n\tfixed_target: %d\n\trate: %f\n\thost: %s\n\turl_path: %s\n\thttp_method: %s", r.FixedTarget, r.Rate, r.Host, r.URLPath, r.HTTPMethod)
 				return r.Sample()
 			}
 		}
 	}
-	log.Tracef("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
+	logger.Debugf("Default rule applies:\n\tfixed_target: %d\n\trate: %f", lss.manifest.Default.FixedTarget, lss.manifest.Default.Rate)
 	return lss.manifest.Default.Sample()
 }

--- a/strategy/sampling/proxy.go
+++ b/strategy/sampling/proxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	xraySvc "github.com/aws/aws-sdk-go/service/xray"
 	"github.com/aws/aws-xray-sdk-go/daemoncfg"
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 )
 
 // proxy is an implementation of svcProxy that forwards requests to the XRay daemon
@@ -31,7 +31,7 @@ func NewProxy(d *daemoncfg.DaemonEndpoints) (svcProxy, error) {
 	if d == nil {
 		d = daemoncfg.GetDaemonEndpoints()
 	}
-	log.Infof("X-Ray proxy using address : %v", d.TCPAddr.String())
+	logger.Infof("X-Ray proxy using address : %v", d.TCPAddr.String())
 	url := "http://" + d.TCPAddr.String()
 
 	// Endpoint resolver for proxying requests through the daemon

--- a/strategy/sampling/sampling_rule.go
+++ b/strategy/sampling/sampling_rule.go
@@ -11,11 +11,11 @@ package sampling
 import (
 	"sync"
 
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/pattern"
 	"github.com/aws/aws-xray-sdk-go/utils"
 
 	xraySvc "github.com/aws/aws-sdk-go/service/xray"
-	log "github.com/cihub/seelog"
 )
 
 // Properties is the base set of properties that define a sampling rule.
@@ -113,7 +113,7 @@ func (r *CentralizedRule) Sample() *Decision {
 	// Fallback to bernoulli sampling if quota has expired
 	if r.reservoir.expired(now) {
 		if r.reservoir.borrow(now) {
-			log.Tracef(
+			logger.Debugf(
 				"Sampling target has expired for rule %s. Borrowing a request.",
 				r.ruleName,
 			)
@@ -123,7 +123,7 @@ func (r *CentralizedRule) Sample() *Decision {
 			return sd
 		}
 
-		log.Tracef(
+		logger.Debugf(
 			"Sampling target has expired for rule %s. Using fixed rate.",
 			r.ruleName,
 		)
@@ -140,7 +140,7 @@ func (r *CentralizedRule) Sample() *Decision {
 		return sd
 	}
 
-	log.Tracef(
+	logger.Debugf(
 		"Sampling target has been exhausted for rule %s. Using fixed rate.",
 		r.ruleName,
 	)

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/resources"
-	log "github.com/cihub/seelog"
 )
 
 const RequestIDKey string = "request_id"
@@ -225,7 +225,7 @@ func parseWhitelistJSON(filename string) []byte {
 	if filename != "" {
 		readBytes, err := ioutil.ReadFile(filename)
 		if err != nil {
-			log.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
+			logger.Errorf("Error occurred while reading customized AWS whitelist JSON file. %v \nReverting to default AWS whitelist JSON file.", err)
 		} else {
 			return readBytes
 		}
@@ -244,7 +244,7 @@ func keyValue(r interface{}, tag string) interface{} {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		log.Errorf("keyValue only accepts structs; got %T", v)
+		logger.Errorf("keyValue only accepts structs; got %T", v)
 	}
 	typ := v.Type()
 	for i := 1; i < v.NumField(); i++ {
@@ -327,7 +327,7 @@ func extractParameters(whitelistKey string, rType int, r *request.Request, white
 	if params != nil {
 		children, err := params.children()
 		if err != nil {
-			log.Errorf("failed to get values for aws attribute: %v", err)
+			logger.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for _, child := range children {
@@ -351,7 +351,7 @@ func extractDescriptors(whitelistKey string, rType int, r *request.Request, whit
 	if responseDtr != nil {
 		items, err := responseDtr.childrenMap()
 		if err != nil {
-			log.Errorf("failed to get values for aws attribute: %v", err)
+			logger.Errorf("failed to get values for aws attribute: %v", err)
 			return
 		}
 		for k := range items {
@@ -374,7 +374,7 @@ func descriptorType(descriptorMap map[string]interface{}) string {
 	} else if descriptorMap["value"] != nil {
 		typeValue = "value"
 	} else {
-		log.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
+		logger.Error("Missing keys in request / response descriptors in AWS whitelist JSON file.")
 	}
 	return typeValue
 }

--- a/xray/client.go
+++ b/xray/client.go
@@ -10,10 +10,11 @@ package xray
 
 import (
 	"context"
-	log "github.com/cihub/seelog"
 	"net/http"
 	"net/http/httptrace"
 	"strconv"
+
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 )
 
 const emptyHostRename = "empty_host_error"
@@ -66,7 +67,7 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		seg := GetSegment(ctx)
 		if seg == nil {
 			resp, err = rt.Base.RoundTrip(r)
-			log.Warnf("failed to record HTTP transaction: segment cannot be found.")
+			logger.Warnf("failed to record HTTP transaction: segment cannot be found.")
 			return err
 		}
 

--- a/xray/config.go
+++ b/xray/config.go
@@ -10,17 +10,17 @@ package xray
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"sync"
 
 	"github.com/aws/aws-xray-sdk-go/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/xraylog"
 
 	"github.com/aws/aws-xray-sdk-go/strategy/ctxmissing"
 	"github.com/aws/aws-xray-sdk-go/strategy/exception"
 	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
-	log "github.com/cihub/seelog"
 )
 
 // SDKVersion records the current X-Ray Go SDK version.
@@ -36,13 +36,16 @@ type SDK struct {
 	RuleName string `json:"sampling_rule_name,omitempty"`
 }
 
+// The logger instance used by xray. Only set from init() functions as
+// SetLogger is not goroutine safe.
+func SetLogger(l xraylog.Logger) {
+	logger.Logger = l
+}
+
 var globalCfg = newGlobalConfig()
 
 func newGlobalConfig() *globalConfig {
 	ret := &globalConfig{}
-
-	// Set the logging configuration to the defaults
-	ret.logLevel, ret.logFormat = loadLogConfig("", "")
 
 	ret.daemonAddr = daemoncfg.GetDaemonEndpoints().UDPAddr
 
@@ -87,8 +90,6 @@ type globalConfig struct {
 	streamingStrategy           StreamingStrategy
 	exceptionFormattingStrategy exception.FormattingStrategy
 	contextMissingStrategy      ctxmissing.Strategy
-	logLevel                    log.LogLevel
-	logFormat                   string
 }
 
 // Config is a set of X-Ray configurations.
@@ -100,8 +101,12 @@ type Config struct {
 	StreamingStrategy           StreamingStrategy
 	ExceptionFormattingStrategy exception.FormattingStrategy
 	ContextMissingStrategy      ctxmissing.Strategy
-	LogLevel                    string
-	LogFormat                   string
+
+	// LogLevel and LogFormat are deprecated and no longer have any effect.
+	// See SetLogger() and the associated xraylog.Logger interface to control
+	// logging.
+	LogLevel  string
+	LogFormat string
 }
 
 // ContextWithConfig returns context with given configuration settings.
@@ -131,8 +136,6 @@ func ContextWithConfig(ctx context.Context, c Config) (context.Context, error) {
 			c.ContextMissingStrategy = cm
 		}
 	}
-
-	loadLogConfig(c.LogLevel, c.LogFormat)
 
 	var err error
 	switch len(errors) {
@@ -206,8 +209,6 @@ func Configure(c Config) error {
 		globalCfg.serviceVersion = c.ServiceVersion
 	}
 
-	globalCfg.logLevel, globalCfg.logFormat = loadLogConfig(c.LogLevel, c.LogFormat)
-
 	switch len(errors) {
 	case 0:
 		return nil
@@ -216,41 +217,6 @@ func Configure(c Config) error {
 	default:
 		return errors
 	}
-}
-
-func loadLogConfig(logLevel string, logFormat string) (log.LogLevel, string) {
-	var level log.LogLevel
-	var format string
-
-	switch logLevel {
-	case "trace":
-		level = log.TraceLvl
-	case "debug":
-		level = log.DebugLvl
-	case "info":
-		level = log.InfoLvl
-	case "warn":
-		level = log.WarnLvl
-	case "error":
-		level = log.ErrorLvl
-	default:
-		level = log.InfoLvl
-		logLevel = "info"
-	}
-
-	if logFormat != "" {
-		format = logFormat
-	} else {
-		format = "%Date(2006-01-02T15:04:05Z07:00) [%Level] %Msg%n"
-	}
-
-	writer, _ := log.NewConsoleWriter()
-	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(writer, level, format)
-	if err != nil {
-		panic(fmt.Errorf("failed to create logs as StdOut: %v", err))
-	}
-	log.ReplaceLogger(logger)
-	return level, format
 }
 
 func (c *globalConfig) DaemonAddr() *net.UDPAddr {
@@ -287,16 +253,4 @@ func (c *globalConfig) ServiceVersion() string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.serviceVersion
-}
-
-func (c *globalConfig) LogLevel() log.LogLevel {
-	c.RLock()
-	defer c.RUnlock()
-	return c.logLevel
-}
-
-func (c *globalConfig) LogFormat() string {
-	c.RLock()
-	defer c.RUnlock()
-	return c.logFormat
 }

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -132,15 +132,11 @@ func TestInvalidEnvironmentDaemonAddress(t *testing.T) {
 
 func TestDefaultConfigureParameters(t *testing.T) {
 	daemonAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2000}
-	logLevel := "info"
-	logFormat := "%Date(2006-01-02T15:04:05Z07:00) [%Level] %Msg%n"
 	efs, _ := exception.NewDefaultFormattingStrategy()
 	sms, _ := NewDefaultStreamingStrategy()
 	cms := ctxmissing.NewDefaultRuntimeErrorStrategy()
 
 	assert.Equal(t, daemonAddr, globalCfg.daemonAddr)
-	assert.Equal(t, logLevel, globalCfg.logLevel.String())
-	assert.Equal(t, logFormat, globalCfg.logFormat)
 	assert.Equal(t, efs, globalCfg.exceptionFormattingStrategy)
 	assert.Equal(t, "", globalCfg.serviceVersion)
 	assert.Equal(t, sms, globalCfg.streamingStrategy)
@@ -170,8 +166,6 @@ func TestSetConfigureParameters(t *testing.T) {
 	})
 
 	assert.Equal(t, &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3000}, globalCfg.daemonAddr)
-	assert.Equal(t, logLevel, globalCfg.logLevel.String())
-	assert.Equal(t, logFormat, globalCfg.logFormat)
 	assert.Equal(t, ss, globalCfg.samplingStrategy)
 	assert.Equal(t, efs, globalCfg.exceptionFormattingStrategy)
 	assert.Equal(t, sms, globalCfg.streamingStrategy)

--- a/xray/default_streaming_strategy.go
+++ b/xray/default_streaming_strategy.go
@@ -12,7 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 )
 
 var defaultMaxSubsegmentCount = 20
@@ -52,7 +52,7 @@ func (dSS *DefaultStreamingStrategy) RequiresStreaming(seg *Segment) bool {
 // StreamCompletedSubsegments separates subsegments from the provided
 // segment tree and sends them to daemon as streamed subsegment UDP packets.
 func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) [][]byte {
-	log.Trace("Beginning to stream subsegments.")
+	logger.Debug("Beginning to stream subsegments.")
 	var outSegments [][]byte
 	for i := 0; i < len(seg.rawSubsegments); i++ {
 		child := seg.rawSubsegments[i]
@@ -71,11 +71,11 @@ func (dSS *DefaultStreamingStrategy) StreamCompletedSubsegments(seg *Segment) []
 		child.beforeEmitSubsegment(seg)
 		cb, _ := json.Marshal(child)
 		outSegments = append(outSegments, cb)
-		log.Tracef("Streaming subsegment named '%s' from segment tree.", child.Name)
+		logger.Debugf("Streaming subsegment named '%s' from segment tree.", child.Name)
 		child.Unlock()
 
 		break
 	}
-	log.Trace("Finished streaming subsegments.")
+	logger.Debug("Finished streaming subsegments.")
 	return outSegments
 }

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -17,12 +17,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
 
 	"github.com/aws/aws-xray-sdk-go/header"
 	"github.com/aws/aws-xray-sdk-go/internal/plugins"
 	"github.com/aws/aws-xray-sdk-go/pattern"
-	log "github.com/cihub/seelog"
 )
 
 // SegmentNamer is the interface for naming service node.
@@ -147,7 +147,7 @@ func httpTrace(seg *Segment, h http.Handler, w http.ResponseWriter, r *http.Requ
 		}
 		sd := seg.ParentSegment.GetConfiguration().SamplingStrategy.ShouldTrace(samplingRequest)
 		seg.Sampled = sd.Sample
-		log.Tracef("SamplingStrategy decided: %t", seg.Sampled)
+		logger.Debugf("SamplingStrategy decided: %t", seg.Sampled)
 		seg.AddRuleName(sd)
 	}
 	if traceHeader.SamplingDecision == header.Requested {

--- a/xray/lambda.go
+++ b/xray/lambda.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-xray-sdk-go/header"
-	log "github.com/cihub/seelog"
+	"github.com/aws/aws-xray-sdk-go/internal/logger"
 )
 
 // LambdaTraceHeaderKey is key to get trace header from context.
@@ -54,11 +54,11 @@ func initLambda() {
 		now := time.Now()
 		filePath, err := createFile(SDKInitializedFileFolder, SDKInitializedFileName)
 		if err != nil {
-			log.Tracef("unable to create file at %s. failed to signal SDK initialization with error: %v", filePath, err)
+			logger.Debugf("unable to create file at %s. failed to signal SDK initialization with error: %v", filePath, err)
 		} else {
 			e := os.Chtimes(filePath, now, now)
 			if e != nil {
-				log.Tracef("unable to write to %s. failed to signal SDK initialization with error: %v", filePath, e)
+				logger.Debugf("unable to write to %s. failed to signal SDK initialization with error: %v", filePath, e)
 			}
 		}
 	}

--- a/xraylog/xray_log.go
+++ b/xraylog/xray_log.go
@@ -1,0 +1,77 @@
+// Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package xraylog
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// Logger is the logging interface used by xray. fmt.Stringer is used to
+// defer expensive serialization operations until the message is actually
+// logged (i.e. don't bother serializing debug messages if they aren't going
+// to show up).
+type Logger interface {
+	Log(level LogLevel, msg fmt.Stringer)
+}
+
+// LogLevel represents the severity of a log message, where a higher value
+// means more severe. The integer value should not be serialized as it is
+// subject to change.
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = iota + 1
+	LogLevelInfo
+	LogLevelWarn
+	LogLevelError
+)
+
+func (ll LogLevel) String() string {
+	switch ll {
+	case LogLevelDebug:
+		return "DEBUG"
+	case LogLevelInfo:
+		return "INFO"
+	case LogLevelWarn:
+		return "WARN"
+	case LogLevelError:
+		return "ERROR"
+	default:
+		return fmt.Sprintf("UNKNOWN<%d>", ll)
+	}
+}
+
+// NewDefaultLogger makes a Logger object that writes newline separated
+// messages to w, if the level of the message is at least minLogLevel.
+func NewDefaultLogger(w io.Writer, minLogLevel LogLevel) Logger {
+	return &defaultLogger{w, minLogLevel}
+}
+
+type defaultLogger struct {
+	w        io.Writer
+	minLevel LogLevel
+}
+
+func (l *defaultLogger) Log(ll LogLevel, msg fmt.Stringer) {
+	if ll < l.minLevel {
+		return
+	}
+
+	fmt.Fprintf(l.w, "%s [%s] %s\n", time.Now().Format(time.RFC3339), ll, msg)
+}
+
+// NullLogger can be used to disable logging (pass to xray.SetLogger()).
+var NullLogger = nullLogger{}
+
+type nullLogger struct{}
+
+func (nl nullLogger) Log(ll LogLevel, msg fmt.Stringer) {
+}


### PR DESCRIPTION
Fixes #15.

Replace seelog with a custom logger interface. This change is backwards compatible except that the existing LogLevel and LogFormat config fields no longer have any effect. Users will have to reset their min log level if they weren't using the default of "info".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
