### PR TITLE
Don't try to udp dial emitter at package load time

### DIFF
--- a/xray/default_emitter.go
+++ b/xray/default_emitter.go
@@ -72,6 +72,7 @@ func (de *DefaultEmitter) Emit(seg *Segment) {
 
 		if de.conn == nil {
 			if err := de.refresh(de.addr); err != nil {
+				de.Unlock()
 				return
 			}
 		}

--- a/xray/default_emitter.go
+++ b/xray/default_emitter.go
@@ -24,23 +24,35 @@ var Header = []byte(`{"format": "json", "version": 1}` + "\n")
 type DefaultEmitter struct {
 	sync.Mutex
 	conn *net.UDPConn
+	addr *net.UDPAddr
 }
 
 // NewDefaultEmitter initializes and returns a
 // pointer to an instance of DefaultEmitter.
 func NewDefaultEmitter(raddr *net.UDPAddr) (*DefaultEmitter, error) {
 	initLambda()
-	d := &DefaultEmitter{}
-	d.RefreshEmitterWithAddress(raddr)
+	d := &DefaultEmitter{addr: raddr}
 	return d, nil
 }
 
 // RefreshEmitterWithAddress dials UDP based on the input UDP address.
 func (de *DefaultEmitter) RefreshEmitterWithAddress(raddr *net.UDPAddr) {
 	de.Lock()
-	de.conn, _ = net.DialUDP("udp", nil, raddr)
-	logger.Infof("Emitter using address: %v", raddr)
+	de.refresh(raddr)
 	de.Unlock()
+}
+
+func (de *DefaultEmitter) refresh(raddr *net.UDPAddr) (err error) {
+	de.conn, err = net.DialUDP("udp", nil, raddr)
+	de.addr = raddr
+
+	if err != nil {
+		logger.Errorf("Error dialing emitter address %v: %s", raddr, err)
+		return err
+	}
+
+	logger.Infof("Emitter using address: %v", raddr)
+	return nil
 }
 
 // Emit segment or subsegment if root segment is sampled.
@@ -57,6 +69,13 @@ func (de *DefaultEmitter) Emit(seg *Segment) {
 			return b.String()
 		})
 		de.Lock()
+
+		if de.conn == nil {
+			if err := de.refresh(de.addr); err != nil {
+				return
+			}
+		}
+
 		_, err := de.conn.Write(append(Header, p...))
 		if err != nil {
 			logger.Error(err)


### PR DESCRIPTION
This is the last non-trivial side effect that happens at package load
time (I think). The problem is the user has not had a chance to
Configure() xray yet, so it always tries dialing the default emitter
address (and logs to stdout before user has configured logger).

Instead of trying to dial a default emitter UDP address at package
load time, defer that operation until we try to Emit() our first
message. We also log and return on errors returned by DialUDP().

Fixes #79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
