### PR TITLE
breaking: updates sampling.NewProxy to be private

### DIFF
--- a/strategy/sampling/centralized.go
+++ b/strategy/sampling/centralized.go
@@ -189,7 +189,7 @@ func (ss *CentralizedStrategy) start() {
 
 	if !ss.pollerStart {
 		var er error
-		ss.proxy, er = NewProxy(ss.daemonEndpoints)
+		ss.proxy, er = newProxy(ss.daemonEndpoints)
 		if er != nil {
 			panic(er)
 		}

--- a/strategy/sampling/proxy.go
+++ b/strategy/sampling/proxy.go
@@ -26,7 +26,7 @@ type proxy struct {
 }
 
 // NewProxy returns a Proxy
-func NewProxy(d *daemoncfg.DaemonEndpoints) (svcProxy, error) {
+func newProxy(d *daemoncfg.DaemonEndpoints) (svcProxy, error) {
 
 	if d == nil {
 		d = daemoncfg.GetDaemonEndpoints()


### PR DESCRIPTION
*Description of changes:*
Makes `NewProxy` a private function by changing it to `newProxy`.

`NewProxy` is used by the centralized sampler to create an x-ray service client that uses the daemon as a proxy when calling `GetSamplingRules` and `GetSamplingTargets`.

Since this is a public method, it's possible that users could be calling this API and relying on the returned values from `GetSamplingRules` and `GetSamplingTargets`. Since these APIs return structs from the AWS SDK v1, we could break consumers of the API if we decide to update our centralized sampler to use the AWS SDK v2.

I feel this method doesn't provide enough value to warrant exposing it publicly, given it ties us to continue using the V1 SDK. It's fairly straightforward to create an X-Ray service client that points to the daemon if that's required outside of the SDK.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
