### PR TITLE
 Add support for tx.Prepare

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@ The following people have contributed to the AWS X-Ray SDK for Go's design and/o
 * Anssi Alaranta
 * Bilal Khan
 * Christopher Radek
+* Jacob Rickerd
 * James Bowman
 * Lulu Zhao
 * Muir Manders

--- a/xray/sql_go18.go
+++ b/xray/sql_go18.go
@@ -82,6 +82,12 @@ func (db *DB) QueryRow(ctx context.Context, query string, args ...interface{}) *
 	return res
 }
 
+// Prepare creates a prepared statement for later queries or executions.
+func (tx *Tx) Prepare(ctx context.Context, query string) (*Stmt, error) {
+	stmt, err := tx.tx.PrepareContext(ctx, query)
+	return &Stmt{tx.db, stmt, query}, err
+}
+
 // Exec captures executing a query that doesn't return rows and adds
 // corresponding information into subsegment.
 func (tx *Tx) Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added support for tx.Prepare method.

When attempting to use the SDK, I noticed I couldn't use this as a 100% drop in replacement due to lack of tx.Prepare support. This pull request address the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
