### PR TITLE
Refactoring of newGlobalConfig to avoid init log

### DIFF
--- a/daemoncfg/daemon_config.go
+++ b/daemoncfg/daemon_config.go
@@ -43,22 +43,35 @@ func GetDaemonEndpoints() *DaemonEndpoints {
 	}
 
 	if daemonEndpoint == nil { // env variable not set
-		udpAddr := &net.UDPAddr{ // use default address
-			IP:   net.IPv4(127, 0, 0, 1),
-			Port: 2000,
-		}
-
-		tcpAddr := &net.TCPAddr{ // use default address
-			IP:   net.IPv4(127, 0, 0, 1),
-			Port: 2000,
-		}
-
-		return &DaemonEndpoints{
-			UDPAddr: udpAddr,
-			TCPAddr: tcpAddr,
-		}
+		return GetDefaultDaemonEndpoints()
 	}
 	return daemonEndpoint // env variable successfully parsed
+}
+
+// GetDaemonEndpointsFromEnv resolves the daemon address if set in the environment variable.
+func GetDaemonEndpointsFromEnv() (*DaemonEndpoints, error) {
+	if envDaemonAddr := os.Getenv("AWS_XRAY_DAEMON_ADDRESS"); envDaemonAddr != "" {
+		return resolveAddress(envDaemonAddr)
+	}
+	return nil, nil
+}
+
+// GetDefaultDaemonEndpoints returns the default UDP and TCP address of the daemon.
+func GetDefaultDaemonEndpoints() *DaemonEndpoints {
+	udpAddr := &net.UDPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 2000,
+	}
+
+	tcpAddr := &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 2000,
+	}
+
+	return &DaemonEndpoints{
+		UDPAddr: udpAddr,
+		TCPAddr: tcpAddr,
+	}
 }
 
 // GetDaemonEndpointsFromString parses provided daemon address if the environment variable is invalid or not set.

--- a/daemoncfg/daemon_config_test.go
+++ b/daemoncfg/daemon_config_test.go
@@ -47,6 +47,45 @@ func TestGetDaemonEndpoints2(t *testing.T) { // default address set to udp and t
 	assert.Equal(t, dEndpt.TCPAddr, tcpEndpt)
 }
 
+func TestGetDaemonEndpointsFromEnv1(t *testing.T) {
+	udpAddr := "127.0.0.1:4000"
+	tcpAddr := "127.0.0.1:5000"
+	udpEndpt, _ := resolveUDPAddr(udpAddr)
+	tcpEndpt, _ := resolveTCPAddr(tcpAddr)
+
+	dAddr := "tcp:" + tcpAddr + " udp:" + udpAddr
+
+	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", dAddr)
+	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
+
+	dEndpt, _ := GetDaemonEndpointsFromEnv()
+
+	assert.Equal(t, dEndpt.UDPAddr, udpEndpt)
+	assert.Equal(t, dEndpt.TCPAddr, tcpEndpt)
+}
+
+func TestGetDaemonEndpointsFromEnv2(t *testing.T) {
+	os.Setenv("AWS_XRAY_DAEMON_ADDRESS", "")
+	defer os.Unsetenv("AWS_XRAY_DAEMON_ADDRESS")
+
+	dEndpt, err := GetDaemonEndpointsFromEnv()
+
+	assert.Nil(t, dEndpt)
+	assert.Nil(t, err)
+}
+
+func TestGetDefaultDaemonEndpoints(t *testing.T) {
+	udpAddr := "127.0.0.1:2000"
+	tcpAddr := "127.0.0.1:2000"
+	udpEndpt, _ := resolveUDPAddr(udpAddr)
+	tcpEndpt, _ := resolveTCPAddr(tcpAddr)
+
+	dEndpt := GetDefaultDaemonEndpoints()
+
+	assert.Equal(t, dEndpt.UDPAddr, udpEndpt)
+	assert.Equal(t, dEndpt.TCPAddr, tcpEndpt)
+}
+
 func TestGetDaemonEndpointsFromString1(t *testing.T) {
 	udpAddr := "127.0.0.1:2000"
 	tcpAddr := "127.0.0.1:2000"

--- a/xray/config.go
+++ b/xray/config.go
@@ -47,7 +47,14 @@ var globalCfg = newGlobalConfig()
 func newGlobalConfig() *globalConfig {
 	ret := &globalConfig{}
 
-	ret.daemonAddr = daemoncfg.GetDaemonEndpoints().UDPAddr
+	daemonEndpoint, err := daemoncfg.GetDaemonEndpointsFromEnv()
+	if err != nil {
+		panic(err)
+	}
+	if daemonEndpoint == nil {
+		daemonEndpoint = daemoncfg.GetDefaultDaemonEndpoints()
+	}
+	ret.daemonAddr = daemonEndpoint.UDPAddr
 
 	ss, err := sampling.NewCentralizedStrategy()
 	if err != nil {


### PR DESCRIPTION
Implemented solution proposed by @yogiraj07 during our discussion of issue #89, specifically [here](https://github.com/aws/aws-xray-sdk-go/issues/89#issuecomment-474082169).

Issue #89 

The initialisation of `globalCfg` caused an info log message to be printed to stdout when the `AWS_XRAY_DAEMON_ADDRESS` environment variable was set. This log message would always use the default logger and could not be suppressed. A new function that is used during the init of `globalCfg` no longer logs the info message, but still resolves the env var if present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
