### PR TITLE
fix datarace for parallel http client request

### DIFF
--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -125,11 +125,9 @@ type SQLData struct {
 
 // DownstreamHeader returns a header for passing to downstream calls.
 func (s *Segment) DownstreamHeader() *header.Header {
-	r := s.ParentSegment.IncomingHeader
-	if r == nil {
-		r = &header.Header{
-			TraceID: s.ParentSegment.TraceID,
-		}
+	r := &header.Header{}
+	if parent := s.ParentSegment.IncomingHeader; parent != nil {
+		*r = *parent // copy parent incoming header
 	}
 	if r.TraceID == "" {
 		r.TraceID = s.ParentSegment.TraceID


### PR DESCRIPTION
There is a datarace problem on `xray/segement_model.go` when I use xray RoundTripper for parallel requests in a http handler like:

```
client -IncomingHeader-> handler
                            |-RoundTrip-> request1
                            |-RoundTrip-> request2
```

Since `Segment.IncomingHeader` object is shared across requests, modifying `IncomingHeader` in `DownstreamHeader` func will cause a datarace.
In this patch, `DownstreamHeader` never rewrite original `IncomingHeader` object.
Instead, it returns a modified copy of `IncomingHeader` for each call if available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
