### PR TITLE
bugfix: close inprogress connect subsegments

### DIFF
--- a/strategy/sampling/centralized_test.go
+++ b/strategy/sampling/centralized_test.go
@@ -2513,12 +2513,14 @@ A:
 			break A
 		default:
 			// Assert that rule was added to manifest and the timestamp refreshed
+			ss.manifest.Lock()
 			if len(ss.manifest.Rules) == 1 &&
 				len(ss.manifest.Index) == 1 &&
 				ss.manifest.refreshedAt == 1500000000 {
-
+				ss.manifest.Unlock()
 				break A
 			}
+			ss.manifest.Unlock()
 		}
 	}
 }

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/stretchr/testify/assert"
@@ -13,8 +14,8 @@ import (
 
 func TestClientFailedConnection(t *testing.T) {
 	svc := lambda.New(session.Must(session.NewSession(&aws.Config{
-		Endpoint: aws.String("fake.endpoint.amazonaws.com"),
-		Region:   aws.String("fake-moon-1")})))
+		Region:   aws.String("fake-moon-1"),
+		Credentials: credentials.NewStaticCredentials("akid", "secret", "noop")})))
 
 	ctx, root := BeginSegment(context.Background(), "Test")
 
@@ -43,6 +44,7 @@ func TestClientFailedConnection(t *testing.T) {
 	// The subsegment should fail since the endpoint is not valid,
 	// and should not be InProgress.
 	connectSubseg := &Segment{}
+	assert.NotEmpty(t, attemptSubseg.Subsegments)
 	assert.NoError(t, json.Unmarshal(attemptSubseg.Subsegments[0], &connectSubseg))
 	assert.Equal(t, "connect", connectSubseg.Name)
 	assert.False(t, connectSubseg.InProgress)

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -28,6 +28,7 @@ func TestClientFailedConnection(t *testing.T) {
 	assert.NoError(t, e)
 
 	subseg := &Segment{}
+	assert.NotEmpty(t, s.Subsegments)
 	assert.NoError(t, json.Unmarshal(s.Subsegments[0], &subseg))
 	assert.True(t, subseg.Fault)
 	// Should contain 'marshal' and 'attempt' subsegments only.

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -3,6 +3,8 @@ package xray
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,9 +14,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestClientSuccessfulConnection(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b := []byte(`{}`)
+		w.WriteHeader(http.StatusOK)
+		w.Write(b)
+	}))
+
+	svc := lambda.New(session.Must(session.NewSession(&aws.Config{
+		Endpoint:    aws.String(ts.URL),
+		Region:      aws.String("fake-moon-1"),
+		Credentials: credentials.NewStaticCredentials("akid", "secret", "noop")})))
+
+	ctx, root := BeginSegment(context.Background(), "Test")
+
+	AWS(svc.Client)
+
+	_, err := svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
+	root.Close(nil)
+	assert.NoError(t, err)
+
+	s, e := TestDaemon.Recv()
+	assert.NoError(t, e)
+
+	subseg := &Segment{}
+	assert.NotEmpty(t, s.Subsegments)
+	assert.NoError(t, json.Unmarshal(s.Subsegments[0], &subseg))
+	assert.False(t, subseg.Fault)
+	assert.NotEmpty(t, subseg.Subsegments)
+
+	attemptSubseg := &Segment{}
+	for _, sub := range subseg.Subsegments {
+		tempSeg := &Segment{}
+		assert.NoError(t, json.Unmarshal(sub, &tempSeg))
+		if tempSeg.Name == "attempt" {
+			attemptSubseg = tempSeg
+			break
+		}
+	}
+
+	assert.Equal(t, "attempt", attemptSubseg.Name)
+	assert.Zero(t, attemptSubseg.openSegments)
+
+	// Connect subsegment will contain multiple child subsegments.
+	// The subsegment should fail since the endpoint is not valid,
+	// and should not be InProgress.
+	connectSubseg := &Segment{}
+	assert.NotEmpty(t, attemptSubseg.Subsegments)
+	assert.NoError(t, json.Unmarshal(attemptSubseg.Subsegments[0], &connectSubseg))
+	assert.Equal(t, "connect", connectSubseg.Name)
+	assert.False(t, connectSubseg.InProgress)
+	assert.NotZero(t, connectSubseg.EndTime)
+	assert.NotEmpty(t, connectSubseg.Subsegments)
+
+	// Ensure that the 'connect' subsegments are completed.
+	for _, sub := range connectSubseg.Subsegments {
+		tempSeg := &Segment{}
+		assert.NoError(t, json.Unmarshal(sub, &tempSeg))
+		assert.False(t, tempSeg.InProgress)
+		assert.NotZero(t, tempSeg.EndTime)
+	}
+}
+
 func TestClientFailedConnection(t *testing.T) {
 	svc := lambda.New(session.Must(session.NewSession(&aws.Config{
-		Region:   aws.String("fake-moon-1"),
+		Region:      aws.String("fake-moon-1"),
 		Credentials: credentials.NewStaticCredentials("akid", "secret", "noop")})))
 
 	ctx, root := BeginSegment(context.Background(), "Test")

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -1,0 +1,50 @@
+package xray
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientFailedConnection(t *testing.T) {
+	svc := lambda.New(session.Must(session.NewSession(&aws.Config{
+		Endpoint: aws.String("fake.endpoint.amazonaws.com"),
+		Region:   aws.String("fake-moon-1")})))
+
+	ctx, root := BeginSegment(context.Background(), "Test")
+
+	AWS(svc.Client)
+
+	_, err := svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
+	root.Close(nil)
+	assert.Error(t, err)
+
+	s, e := TestDaemon.Recv()
+	assert.NoError(t, e)
+
+	subseg := &Segment{}
+	assert.NoError(t, json.Unmarshal(s.Subsegments[0], &subseg))
+	assert.True(t, subseg.Fault)
+	// Should contain 'marshal' and 'attempt' subsegments only.
+	assert.Len(t, subseg.Subsegments, 2)
+
+	attemptSubseg := &Segment{}
+	assert.NoError(t, json.Unmarshal(subseg.Subsegments[1], &attemptSubseg))
+	assert.Equal(t, "attempt", attemptSubseg.Name)
+	assert.Zero(t, attemptSubseg.openSegments)
+
+	// Connect subsegment will contain multiple child subsegments.
+	// The subsegment should fail since the endpoint is not valid,
+	// and should not be InProgress.
+	connectSubseg := &Segment{}
+	assert.NoError(t, json.Unmarshal(attemptSubseg.Subsegments[0], &connectSubseg))
+	assert.Equal(t, "connect", connectSubseg.Name)
+	assert.False(t, connectSubseg.InProgress)
+	assert.NotZero(t, connectSubseg.EndTime)
+	assert.NotEmpty(t, connectSubseg.Subsegments)
+}

--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -196,6 +196,32 @@ func TestBadRoundTrip(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%v", err), subseg.Cause.Exceptions[0].Message)
 }
 
+func TestBadRoundTripDial(t *testing.T) {
+	ctx, root := BeginSegment(context.Background(), "Test")
+	reader := strings.NewReader("")
+	// Make a request against an unreachable endpoint.
+	req := httptest.NewRequest("GET", "https://0.0.0.0:0", reader)
+	req = req.WithContext(ctx)
+	_, err := rt.RoundTrip(req)
+	root.Close(nil)
+	assert.Error(t, err)
+
+	s, e := TestDaemon.Recv()
+	assert.NoError(t, e)
+	subseg := &Segment{}
+	assert.NoError(t, json.Unmarshal(s.Subsegments[0], &subseg))
+	assert.Equal(t, fmt.Sprintf("%v", err), subseg.Cause.Exceptions[0].Message)
+
+	// Also ensure that the 'connect' subsegment is closed and showing fault
+	connectSeg := &Segment{}
+	assert.NoError(t, json.Unmarshal(subseg.Subsegments[0], &connectSeg))
+	assert.Equal(t, "connect", connectSeg.Name)
+	assert.NotZero(t, connectSeg.EndTime)
+	assert.False(t, connectSeg.InProgress)
+	assert.True(t, connectSeg.Fault)
+	assert.NotEmpty(t, connectSeg.Subsegments)
+}
+
 func TestRoundTripReuseDatarace(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b := []byte(`200 - Nothing to see`)

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -285,7 +285,7 @@ func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
 			seg.rawSubsegments[len(seg.rawSubsegments)-1] = nil
 			seg.rawSubsegments = seg.rawSubsegments[:len(seg.rawSubsegments)-1]
 
-			seg.totalSubSegments--
+			seg.ParentSegment.totalSubSegments--
 			seg.openSegments--
 			return true
 		}


### PR DESCRIPTION
*Issue #, if available:*
#87 

*Description of changes:*
The SDK sometimes generates a `connect` subsegment when tracing the AWS SDK, or using the traced HTTP client. In some cases, the `connect` subsegment is not closed, preventing its parent segment from being closed. This causes problems in Lambda, where we can't wait for the context passed to the facade segments to be `done` before emitting.

This change closes the `connect` subsegment when it is reasonable to assume that a connection was attempt has been completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
