### PR TITLE
fix dataraces by #102

### DIFF
--- a/xray/aws.go
+++ b/xray/aws.go
@@ -105,7 +105,7 @@ var xRayAfterSendHandler = request.NamedHandler{
 	Fn: func(r *request.Request) {
 		curseg := GetSegment(r.HTTPRequest.Context())
 
-		if curseg.Name == "attempt" {
+		if curseg != nil && curseg.Name == "attempt" {
 			// An error could have prevented the connect subsegment from closing,
 			// so clean it up here.
 			for _, subsegment := range curseg.rawSubsegments {

--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -47,6 +47,8 @@ func (xt *HTTPSubsegments) GetConn(hostPort string) {
 // DNSStart begins a dns subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) DNSStart(info httptrace.DNSStartInfo) {
+	xt.mu.Lock()
+	defer xt.mu.Unlock()
 	if GetSegment(xt.opCtx).safeInProgress() && xt.connCtx != nil {
 		xt.dnsCtx, _ = BeginSubsegment(xt.connCtx, "dns")
 	}
@@ -71,6 +73,8 @@ func (xt *HTTPSubsegments) DNSDone(info httptrace.DNSDoneInfo) {
 // ConnectStart begins a dial subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) ConnectStart(network, addr string) {
+	xt.mu.Lock()
+	defer xt.mu.Unlock()
 	if GetSegment(xt.opCtx).safeInProgress() && xt.connCtx != nil {
 		xt.connectCtx, _ = BeginSubsegment(xt.connCtx, "dial")
 	}

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -285,6 +285,10 @@ func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
 			seg.rawSubsegments[len(seg.rawSubsegments)-1] = nil
 			seg.rawSubsegments = seg.rawSubsegments[:len(seg.rawSubsegments)-1]
 
+			if seg.ParentSegment != seg {
+				seg.ParentSegment.Lock()
+				defer seg.ParentSegment.Unlock()
+			}
 			seg.ParentSegment.totalSubSegments--
 			seg.openSegments--
 			return true


### PR DESCRIPTION
I've found some dataraces  induced by #102 and fixed them.
See attachment files for details.
(How can we avoid such data race hell with httprace...?)

(*EDIT*) I also fixed a nil panic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[race2.txt](https://github.com/aws/aws-xray-sdk-go/files/3041794/race2.txt)
[race3.txt](https://github.com/aws/aws-xray-sdk-go/files/3041795/race3.txt)
[race.txt](https://github.com/aws/aws-xray-sdk-go/files/3041796/race.txt)

