### PR TITLE
upkeep: adds -race to travis test scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     fi
 
 script:
-  - make test
+  - make test-with-race
 
 matrix:
   allow_failures:

--- a/makefile
+++ b/makefile
@@ -14,5 +14,8 @@ lint:
 test::
 	go test -cover `go list ./... | grep -v vendor`
 
+test-with-race: test
+	go test -cover -race `go list ./... | grep -v vendor`
+
 fmt:
 	go fmt `go list ./... | grep -v vendor`


### PR DESCRIPTION
*Description of changes:*
Updates our travis builds to run tests with `-race` as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
