### PR TITLE
fix nilp error by #102 for tls conn (again)

### DIFF
--- a/xray/httptrace.go
+++ b/xray/httptrace.go
@@ -97,7 +97,7 @@ func (xt *HTTPSubsegments) ConnectDone(network, addr string, err error) {
 // TLSHandshakeStart begins a tls subsegment if the HTTP operation
 // subsegment is still in progress.
 func (xt *HTTPSubsegments) TLSHandshakeStart() {
-	if GetSegment(xt.opCtx).safeInProgress() {
+	if GetSegment(xt.opCtx).safeInProgress() && xt.connCtx != nil {
 		xt.tlsCtx, _ = BeginSubsegment(xt.connCtx, "tls")
 	}
 }

--- a/xray/util_test.go
+++ b/xray/util_test.go
@@ -74,7 +74,7 @@ func (td *Testdaemon) Run() {
 }
 
 func (td *Testdaemon) Recv() (*Segment, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	select {
 	case r := <-td.Channel:


### PR DESCRIPTION
*Issue #105

*Description of changes:*
Fix nil pointer error again with a test fix due to timeout.

The test job https://travis-ci.org/aws/aws-xray-sdk-go/jobs/520674954 is failed for go1.9 env only.
However, if I set GOMAXPROCS=1 and run tests, it reproduces that test fail.
Maybe Recv timeout 100ms is too short for single goroutine env.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
