### PR TITLE
Update lock abstraction of defaultLogger.

### DIFF
--- a/xraylog/xray_log.go
+++ b/xraylog/xray_log.go
@@ -61,7 +61,7 @@ func NewDefaultLogger(w io.Writer, minLogLevel LogLevel) Logger {
 }
 
 type defaultLogger struct {
-	sync.Mutex
+	mu sync.Mutex
 	w        io.Writer
 	minLevel LogLevel
 }
@@ -71,8 +71,8 @@ func (l *defaultLogger) Log(ll LogLevel, msg fmt.Stringer) {
 		return
 	}
 
-	l.Lock()
-	defer l.Unlock()
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	fmt.Fprintf(l.w, "%s [%s] %s\n", time.Now().Format(time.RFC3339), ll, msg)
 }
 


### PR DESCRIPTION
Just a first small change about how locks are referenced.  This moves
the lock from an extension like parameter of defaultLogger to a
private member

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.