### PR TITLE
Move mutex to private member for sampling.

### DIFF
--- a/strategy/sampling/centralized_test.go
+++ b/strategy/sampling/centralized_test.go
@@ -2513,14 +2513,14 @@ A:
 			break A
 		default:
 			// Assert that rule was added to manifest and the timestamp refreshed
-			ss.manifest.Lock()
+			ss.manifest.mu.Lock()
 			if len(ss.manifest.Rules) == 1 &&
 				len(ss.manifest.Index) == 1 &&
 				ss.manifest.refreshedAt == 1500000000 {
-				ss.manifest.Unlock()
+				ss.manifest.mu.Unlock()
 				break A
 			}
-			ss.manifest.Unlock()
+			ss.manifest.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
Moving mutex to a private member since it does not make
sense to allow other actors to lock/unlock a sampling