### PR TITLE
hide database user info in connection string when it's invalid

### DIFF
--- a/xray/sql_test.go
+++ b/xray/sql_test.go
@@ -122,6 +122,26 @@ func (s *sqlTestSuite) TestPasswordURLSchemaless() {
 	s.Equal("user@host:port/database", s.db.url)
 }
 
+func (s *sqlTestSuite) TestPasswordURLSchemalessWithProtocol() {
+	s.mockDB("mysql://user:password@tcp(host:port)/database?parseTime=true")
+	s.mockPSQL(nil)
+	s.connect()
+ 
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("", s.db.connectionString)
+	s.Equal("mysql://user@tcp(host:port)/database?parseTime=true", s.db.url)
+}
+ 
+func (s *sqlTestSuite) TestInValidUserInfoURLSchemaless() {
+	s.mockDB("mysql://user:passwo[]rd@tcp(host:port)/database?parseTime=true")
+	s.mockPSQL(nil)
+	s.connect()
+ 
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("tcp(host:port)/database?parseTime=true", s.db.connectionString)
+	s.Equal("", s.db.url)
+}
+
 func (s *sqlTestSuite) TestPasswordURLSchemalessUserlessQuery() {
 	s.mockDB("host:port/database?password=password")
 	s.mockPSQL(nil)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-go/issues/131

*Description of changes:*
If database's username/password is invalid, current sdk cannot stripe password.

The change will handle the error `net/url: invalid userinfo` from url.go and remove the user info part of the DSN.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
