### PR TITLE
Fixing bi-directional locking for parent-child segments and modifying lock on Segment struct to RWMutex

### DIFF
--- a/strategy/sampling/centralized.go
+++ b/strategy/sampling/centralized.go
@@ -444,11 +444,12 @@ func (ss *CentralizedStrategy) refreshTargets() (err error) {
 // samplingStatistics takes a snapshot of sampling statistics from all rules, resetting
 // statistics counters in the process.
 func (ss *CentralizedStrategy) snapshots() []*xraySvc.SamplingStatisticsDocument {
-	statistics := make([]*xraySvc.SamplingStatisticsDocument, 0, len(ss.manifest.Rules)+1)
 	now := ss.clock.Now().Unix()
 
 	ss.manifest.mu.RLock()
 	defer ss.manifest.mu.RUnlock()
+
+	statistics := make([]*xraySvc.SamplingStatisticsDocument, 0, len(ss.manifest.Rules)+1)
 
 	// Generate sampling statistics for user-defined rules
 	for _, r := range ss.manifest.Rules {

--- a/strategy/sampling/sampling_rule.go
+++ b/strategy/sampling/sampling_rule.go
@@ -92,8 +92,8 @@ type CentralizedRule struct {
 
 // stale returns true if the quota is due for a refresh. False otherwise.
 func (r *CentralizedRule) stale(now int64) bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 
 	return r.requests != 0 && now >= r.reservoir.refreshedAt+r.reservoir.interval
 }

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -93,7 +93,7 @@ var xRayAfterSendHandler = request.NamedHandler{
 	Fn: func(r *request.Request) {
 		curseg := GetSegment(r.HTTPRequest.Context())
 
-		if curseg != nil && curseg.Name == "attempt" {
+		if curseg != nil && curseg.getName() == "attempt" {
 			// An error could have prevented the connect subsegment from closing,
 			// so clean it up here.
 			curseg.RLock()

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -93,14 +93,15 @@ var xRayAfterSendHandler = request.NamedHandler{
 	Fn: func(r *request.Request) {
 		curseg := GetSegment(r.HTTPRequest.Context())
 
-		if curseg != nil && curseg.getName() == "attempt" {
+		if curseg != nil && curseg.Name == "attempt" {
 			// An error could have prevented the connect subsegment from closing,
 			// so clean it up here.
 			curseg.RLock()
-			s := curseg.rawSubsegments
+			temp := make([]*Segment, len(curseg.rawSubsegments))
+			copy(temp, curseg.rawSubsegments)
 			curseg.RUnlock()
 
-			for _, subsegment := range s {
+			for _, subsegment := range temp {
 				if subsegment.getName() == "connect" && subsegment.safeInProgress() {
 					subsegment.Close(nil)
 					return

--- a/xray/aws.go
+++ b/xray/aws.go
@@ -96,8 +96,12 @@ var xRayAfterSendHandler = request.NamedHandler{
 		if curseg != nil && curseg.Name == "attempt" {
 			// An error could have prevented the connect subsegment from closing,
 			// so clean it up here.
-			for _, subsegment := range curseg.rawSubsegments {
-				if subsegment.Name == "connect" && subsegment.safeInProgress() {
+			curseg.RLock()
+			s := curseg.rawSubsegments
+			curseg.RUnlock()
+
+			for _, subsegment := range s {
+				if subsegment.getName() == "connect" && subsegment.safeInProgress() {
 					subsegment.Close(nil)
 					return
 				}

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -205,6 +205,7 @@ func testAWSDataRace(t *testing.T, svc *lambda.Lambda) {
 				defer wg.Done()
 			}
 			_, seg := BeginSubsegment(ctx, "TestSubsegment1")
+			time.Sleep(1)
 			seg.Close(nil)
 			svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
 			if i== 3 || i==2{

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -205,7 +205,6 @@ func testAWSDataRace(t *testing.T, svc *lambda.Lambda) {
 				defer wg.Done()
 			}
 			_, seg := BeginSubsegment(ctx, "TestSubsegment1")
-			time.Sleep(1)
 			seg.Close(nil)
 			svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
 			if i== 3 || i==2{

--- a/xray/default_emitter.go
+++ b/xray/default_emitter.go
@@ -56,6 +56,7 @@ func (de *DefaultEmitter) refresh(raddr *net.UDPAddr) (err error) {
 }
 
 // Emit segment or subsegment if root segment is sampled.
+// seg has a write lock acquired by the caller.
 func (de *DefaultEmitter) Emit(seg *Segment) {
 	if seg == nil || !seg.ParentSegment.Sampled {
 		return
@@ -85,6 +86,7 @@ func (de *DefaultEmitter) Emit(seg *Segment) {
 	}
 }
 
+// seg has a write lock acquired by the caller.
 func packSegments(seg *Segment, outSegments [][]byte) [][]byte {
 	trimSubsegment := func(s *Segment) []byte {
 		ss := globalCfg.StreamingStrategy()

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -361,10 +361,18 @@ func (seg *Segment) flush() bool {
 }
 
 func (seg *Segment) safeInProgress() bool {
-	seg.Lock()
+	seg.RLock()
 	b := seg.InProgress
-	seg.Unlock()
+	seg.RUnlock()
 	return b
+}
+
+// getName returns name of the segment. This method is thread safe.
+func (seg *Segment) getName() string {
+	seg.RLock()
+	n := seg.Name
+	seg.RUnlock()
+	return n
 }
 
 func (seg *Segment) root() *Segment {

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -286,7 +286,7 @@ func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
 				seg.Unlock()
 
 				atomic.AddUint32(&seg.ParentSegment.totalSubSegments, ^uint32(0))
-			} else{
+			} else {
 				seg.Unlock()
 			}
 

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -232,7 +232,7 @@ func NewSegmentFromHeader(ctx context.Context, name string, h *header.Header) (c
 // Close a segment.
 func (seg *Segment) Close(err error) {
 	seg.Lock()
-	if seg.parent != nil || seg.Type == "Subsegment" {
+	if seg.parent != nil {
 		logger.Debugf("Closing subsegment named %s", seg.Name)
 	} else {
 		logger.Debugf("Closing segment named %s", seg.Name)

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -320,7 +320,7 @@ func (seg *Segment) emit() {
 	seg.ParentSegment.GetConfiguration().Emitter.Emit(seg)
 }
 
-func (seg *Segment)    handleContextDone() {
+func (seg *Segment) handleContextDone() {
 	seg.Lock()
 	seg.ContextDone = true
 	if !seg.InProgress && !seg.Emitted {

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -286,7 +286,7 @@ func (seg *Segment) RemoveSubsegment(remove *Segment) bool {
 				seg.Unlock()
 
 				atomic.AddUint32(&seg.ParentSegment.totalSubSegments, ^uint32(0))
-			}else{
+			} else{
 				seg.Unlock()
 			}
 

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -19,7 +19,7 @@ import (
 
 // Segment provides the resource's name, details about the request, and details about the work done.
 type Segment struct {
-	sync.Mutex
+	sync.RWMutex
 	parent           *Segment
 	openSegments     int
 	totalSubSegments uint32

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -22,7 +22,7 @@ type Segment struct {
 	sync.Mutex
 	parent           *Segment
 	openSegments     int
-	totalSubSegments int
+	totalSubSegments uint32
 	Sampled          bool           `json:"-"`
 	RequestWasTraced bool           `json:"-"` // Used by xray.RequestWasTraced
 	ContextDone      bool           `json:"-"`

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSegmentDataRace(t *testing.T) {
@@ -93,4 +94,33 @@ func TestSegmentDownstreamHeader(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestParentSegmentTotalCount(t *testing.T) {
+	ctx := context.Background()
+
+	ctx, seg := BeginSegment(ctx,"test")
+
+
+	wg := sync.WaitGroup{}
+	n := 2
+	wg.Add(2 * n)
+
+	for i := 0; i < n; i++ {
+		go func(ctx context.Context) { // add async nested subsegments
+			c1,_ := BeginSubsegment(ctx, "TestSubsegment1")
+			c2,_ := BeginSubsegment(c1, "TestSubsegment2")
+
+			go func(ctx context.Context) { // add async nested subsegments
+				c1,_ := BeginSubsegment(ctx, "TestSubsegment1")
+				BeginSubsegment(c1, "TestSubsegment2")
+                wg.Done()
+			}(c2) // passing context
+
+			wg.Done()
+		}(ctx)
+	}
+	wg.Wait()
+
+    assert.Equal(t, 4 * uint32(n) , seg.ParentSegment.totalSubSegments, "totalSubSegments count should be correctly registered on the parent segment")
 }


### PR DESCRIPTION
*Issue #118 , #136:*

*Description of changes:*
1. Bi-directional locking on parent/child (Sub)Segment leads to deadlocks
and data race conditions. This commit fixes this issue by making locking
uni-directional.

2. Changed lock on `Segment` struct to `RWMutex`. Added thread safe block for closing `connect` subsegment in aws.go. Changed lock to read access on `SafeInProgress()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
