### PR TITLE
AddAnnotation allow int64 and uint64

### DIFF
--- a/xray/context_test.go
+++ b/xray/context_test.go
@@ -54,6 +54,12 @@ func TestValidAnnotations(t *testing.T) {
 	if e := AddAnnotation(ctx, "float", 1.1); e != nil {
 		err = append(err, e)
 	}
+	if e := AddAnnotation(ctx, "int64", int64(1)); e != nil {
+		err = append(err, e)
+	}
+	if e := AddAnnotation(ctx, "uint64", uint64(1)); e != nil {
+		err = append(err, e)
+	}
 	root.Close(err)
 
 	s, e := TestDaemon.Recv()
@@ -63,6 +69,8 @@ func TestValidAnnotations(t *testing.T) {
 	assert.Equal(t, 1.0, s.Annotations["int"]) //json encoder turns this into a float64
 	assert.Equal(t, 1.1, s.Annotations["float"])
 	assert.Equal(t, true, s.Annotations["bool"])
+	assert.Equal(t, int64(1), s.Annotations["int64"])
+	assert.Equal(t, uint64(1), s.Annotations["uint64"])
 }
 
 func TestInvalidAnnotations(t *testing.T) {

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -390,7 +390,7 @@ func (sub *Segment) beforeEmitSubsegment(seg *Segment) {
 // AddAnnotation allows adding an annotation to the segment.
 func (seg *Segment) AddAnnotation(key string, value interface{}) error {
 	switch value.(type) {
-	case bool, int, uint, float32, float64, string:
+	case bool, int, uint, int64, uint64, float32, float64, string:
 	default:
 		return fmt.Errorf("failed to add annotation key: %q value: %q to subsegment %q. value must be of type string, number or boolean", key, value, seg.Name)
 	}


### PR DESCRIPTION
*Issue #, if available:*

AddAnnotation does not support int64 and uint64

*Description of changes:*

Just add int64 and uint64

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
