### PR TITLE
Fixed one source of memory leak

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -68,13 +68,14 @@ func BeginSegment(ctx context.Context, name string) (context.Context, *Segment) 
 		seg.GetService().Version = seg.ParentSegment.GetConfiguration().ServiceVersion
 	}
 
-	go func() {
-		select {
-		case <-ctx.Done():
-			seg.handleContextDone()
-		}
-	}()
-
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				seg.handleContextDone()
+			}
+		}()
+	}
 	return context.WithValue(ctx, ContextKey, seg), seg
 }
 
@@ -246,7 +247,6 @@ func (seg *Segment) Close(err error) {
 	seg.Unlock()
 	seg.send()
 }
-
 
 // CloseAndStream closes a subsegment and sends it.
 func (subseg *Segment) CloseAndStream(err error) {


### PR DESCRIPTION
When using the Background context, the Done channel is nil

*Issue #, if available:*
#51

*Description of changes:*
Don't bother selecting a nil channel because it waits forever and leaks memory.

Issue 51 has a more comprehensive fix suggested by Cyberax, but if not going to integrate that fix or there some hold-up, at least make this trivial fix in the mean time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
