### PR TITLE
fix race condition of the default emitter

### DIFF
--- a/xray/default_emitter_test.go
+++ b/xray/default_emitter_test.go
@@ -143,6 +143,9 @@ func getTestSegment() string {
 }
 
 func BenchmarkDefaultEmitter(b *testing.B) {
+	// make sure `Header` has enough capacity
+	// to reproduce https://github.com/aws/aws-xray-sdk-go/pull/173
+	// minimum capacity is guaranteed by Go specs, but actual capacity is not.
 	Header = append(make([]byte, 0, 1024), Header...)
 
 	seg := &Segment{

--- a/xray/default_emitter_test.go
+++ b/xray/default_emitter_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net"
 	"testing"
 	"time"
 
@@ -139,4 +140,26 @@ func getTestSegment() string {
 		traceID,
 		randomString(16))
 	return message
+}
+
+func BenchmarkDefaultEmitter(b *testing.B) {
+	Header = append(make([]byte, 0, 1024), Header...)
+
+	seg := &Segment{
+		ParentSegment: &Segment{
+			Sampled: true,
+		},
+	}
+	b.RunParallel(func(pb *testing.PB) {
+		emitter, err := NewDefaultEmitter(&net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 2000,
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		for pb.Next() {
+			emitter.Emit(seg)
+		}
+	})
 }

--- a/xray/util_test.go
+++ b/xray/util_test.go
@@ -9,6 +9,7 @@
 package xray
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -60,7 +61,8 @@ func (td *Testdaemon) Run() {
 			continue
 		}
 
-		buffered := buffer[len(Header):n]
+		idx := bytes.IndexByte(buffer, 'n')
+		buffered := buffer[idx+1 : n]
 
 		seg := &Segment{}
 		err = json.Unmarshal(buffered, &seg)

--- a/xray/util_test.go
+++ b/xray/util_test.go
@@ -61,7 +61,7 @@ func (td *Testdaemon) Run() {
 			continue
 		}
 
-		idx := bytes.IndexByte(buffer, 'n')
+		idx := bytes.IndexByte(buffer, '\n')
 		buffered := buffer[idx+1 : n]
 
 		seg := &Segment{}


### PR DESCRIPTION
*Issue #, if available:*

There is a race condition on `xray.(*DefaultEmitter).Emit()`.

```
Running tool: /usr/local/bin/go test -benchmem -run=^$ github.com/aws/aws-xray-sdk-go/xray -bench ^(BenchmarkDefaultEmitter)$ -v -race

2020-01-15T07:44:55+09:00 [INFO] Emitter using address: 127.0.0.1:2000
goos: darwin
goarch: amd64
pkg: github.com/aws/aws-xray-sdk-go/xray
BenchmarkDefaultEmitter-4   	2020-01-15T07:44:55+09:00 [INFO] Emitter using address: 127.0.0.1:2000
2020-01-15T07:44:55+09:00 [INFO] Emitter using address: 127.0.0.1:2000
==================
2020-01-15T07:44:55+09:00 [INFO] Emitter using address: 127.0.0.1:2000
WARNING: DATA RACE
Write at 0x00c0000cc821 by goroutine 22:
  runtime.slicecopy()
      /usr/local/Cellar/go/1.13.6/libexec/src/runtime/slice.go:197 +0x0
  github.com/aws/aws-xray-sdk-go/xray.(*DefaultEmitter).Emit()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter.go:81 +0x347
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter.func1()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:162 +0x255
  testing.(*B).RunParallel.func1()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:742 +0x179

Previous read at 0x00c0000cc820 by goroutine 21:
  syscall.Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/internal/race/race.go:45 +0xab
  internal/poll.(*FD).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/internal/poll/fd_unix.go:268 +0x1f8
  net.(*netFD).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/net/fd_unix.go:220 +0x65
  net.(*conn).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/net/net.go:196 +0xa0
  github.com/aws/aws-xray-sdk-go/xray.(*DefaultEmitter).Emit()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter.go:81 +0x390
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter.func1()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:162 +0x255
  testing.(*B).RunParallel.func1()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:742 +0x179

Goroutine 22 (running) created at:
  testing.(*B).RunParallel()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:735 +0x256
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:153 +0x2df
  testing.(*B).runN()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:190 +0x162
  testing.(*B).launch()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:320 +0x156

Goroutine 21 (running) created at:
  testing.(*B).RunParallel()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:735 +0x256
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:153 +0x2df
  testing.(*B).runN()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:190 +0x162
  testing.(*B).launch()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:320 +0x156
==================
==================
WARNING: DATA RACE
Write at 0x00c0000cc821 by goroutine 23:
  runtime.slicecopy()
      /usr/local/Cellar/go/1.13.6/libexec/src/runtime/slice.go:197 +0x0
  github.com/aws/aws-xray-sdk-go/xray.(*DefaultEmitter).Emit()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter.go:81 +0x347
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter.func1()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:162 +0x255
  testing.(*B).RunParallel.func1()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:742 +0x179

Previous read at 0x00c0000cc820 by goroutine 21:
  syscall.Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/internal/race/race.go:45 +0xab
  internal/poll.(*FD).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/internal/poll/fd_unix.go:268 +0x1f8
  net.(*netFD).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/net/fd_unix.go:220 +0x65
  net.(*conn).Write()
      /usr/local/Cellar/go/1.13.6/libexec/src/net/net.go:196 +0xa0
  github.com/aws/aws-xray-sdk-go/xray.(*DefaultEmitter).Emit()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter.go:81 +0x390
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter.func1()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:162 +0x255
  testing.(*B).RunParallel.func1()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:742 +0x179

Goroutine 23 (running) created at:
  testing.(*B).RunParallel()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:735 +0x256
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:153 +0x2df
  testing.(*B).runN()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:190 +0x162
  testing.(*B).launch()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:320 +0x156

Goroutine 21 (running) created at:
  testing.(*B).RunParallel()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:735 +0x256
  github.com/aws/aws-xray-sdk-go/xray.BenchmarkDefaultEmitter()
      /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/default_emitter_test.go:153 +0x2df
  testing.(*B).runN()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:190 +0x162
  testing.(*B).launch()
      /usr/local/Cellar/go/1.13.6/libexec/src/testing/benchmark.go:320 +0x156
==================
2020-01-15T07:44:55+09:00 [INFO] Emitter using address: 127.0.0.1:2000
--- FAIL: BenchmarkDefaultEmitter-4
    /Users/shogoichinose/src/github.com/shogo82148/aws-xray-sdk-go/xray/benchmark.go:196: race detected during execution of benchmark
FAIL
exit status 1
FAIL	github.com/aws/aws-xray-sdk-go/xray	0.420s
FAIL
Error: Benchmarks failed.
```

*Description of changes:*

I removed `append(Header, p...)`.
`p` is written to `Header[len(Header):cap(Header)]` if there is enough capacity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
