### PR TITLE
rename tip to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - "1.10"
   - "1.11"
   - "1.12"
-  - "tip"
+  - "master"
 
 notifications:
   email:


### PR DESCRIPTION
*Issue #, if available:*

ref. https://github.com/aws/aws-xray-sdk-go/pull/172#issuecomment-574407521

*Description of changes:*

`tip` version on traivs-ci (may) be renamed to `master`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
