### PR TITLE
fixed inconsistent test failures and sql test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,11 +29,14 @@ jobs:
       - name: Set up GOPATH
         run: |
           go version
-          echo "::set-env name=GOPATH::$GITHUB_WORKSPACE"
+          echo "::set-env name=GOPATH::${{ github.workspace }}"
           echo "::add-path::${{ github.workspace }}/bin"
-          mkdir -p "$GITHUB_WORKSPACE/bin"
-          mkdir -p "$GITHUB_WORKSPACE/pkg"
-          mkdir -p "$GITHUB_WORKSPACE/src"
+          mkdir -p "bin"
+          mkdir -p "pkg"
+          mkdir -p "src"
+
+          # for dep, bash and Windows
+          echo "::set-env name=INSTALL_DIRECTORY::$(pwd)/bin"
         shell: bash
       - name: Check out code
         uses: actions/checkout@v2

--- a/xray/aws_test.go
+++ b/xray/aws_test.go
@@ -96,6 +96,7 @@ func fakeSession(t *testing.T, failConn bool) *session.Session {
 }
 
 func testClientSuccessfulConnection(t *testing.T, svc *lambda.Lambda) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	_, err := svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
 	root.Close(nil)
@@ -144,6 +145,7 @@ func testClientSuccessfulConnection(t *testing.T, svc *lambda.Lambda) {
 }
 
 func testClientFailedConnection(t *testing.T, svc *lambda.Lambda) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	_, err := svc.ListFunctionsWithContext(ctx, &lambda.ListFunctionsInput{})
 	root.Close(nil)

--- a/xray/capture_test.go
+++ b/xray/capture_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestSimpleCapture(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	err := Capture(ctx, "TestService", func(ctx1 context.Context) error {
 		ctx = ctx1
@@ -42,6 +43,7 @@ func TestSimpleCapture(t *testing.T) {
 }
 
 func TestCaptureAysnc(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	CaptureAsync(ctx, "TestService", func(ctx1 context.Context) error {
 		ctx = ctx1
@@ -63,6 +65,7 @@ func TestCaptureAysnc(t *testing.T) {
 }
 
 func TestErrorCapture(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	defaultStrategy, _ := exception.NewDefaultFormattingStrategy()
 	err := Capture(ctx, "ErrorService", func(ctx1 context.Context) error {
@@ -82,6 +85,7 @@ func TestErrorCapture(t *testing.T) {
 }
 
 func TestPanicCapture(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	var err error
 	func() {
@@ -127,6 +131,7 @@ func TestNoSegmentCapture(t *testing.T) {
 
 func TestCaptureAsync(t *testing.T) {
 	var mu sync.Mutex
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	CaptureAsync(ctx, "TestService", func(ctx1 context.Context) error {
 		mu.Lock()

--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -49,6 +49,7 @@ func TestRoundTripper(t *testing.T) {
 func TestRoundTrip(t *testing.T) {
 	var responseContentLength int
 	var headers XRayHeaders
+	TestDaemon.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headers = ParseHeadersForTest(r.Header)
 		b := []byte(`200 - Nothing to see`)
@@ -106,6 +107,7 @@ func TestRoundTrip(t *testing.T) {
 func TestRoundTripWithError(t *testing.T) {
 	var responseContentLength int
 	var headers XRayHeaders
+	TestDaemon.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headers = ParseHeadersForTest(r.Header)
 		b := []byte(`403 - Nothing to see`)
@@ -139,6 +141,7 @@ func TestRoundTripWithError(t *testing.T) {
 func TestRoundTripWithThrottle(t *testing.T) {
 	var responseContentLength int
 	var headers XRayHeaders
+	TestDaemon.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headers = ParseHeadersForTest(r.Header)
 
@@ -173,6 +176,7 @@ func TestRoundTripWithThrottle(t *testing.T) {
 func TestRoundTripFault(t *testing.T) {
 	var responseContentLength int
 	var headers XRayHeaders
+	TestDaemon.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headers = ParseHeadersForTest(r.Header)
 
@@ -205,6 +209,7 @@ func TestRoundTripFault(t *testing.T) {
 }
 
 func TestBadRoundTrip(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	reader := strings.NewReader("")
 	req := httptest.NewRequest("GET", "httpz://localhost:8000", reader)
@@ -221,6 +226,7 @@ func TestBadRoundTrip(t *testing.T) {
 }
 
 func TestBadRoundTripDial(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	reader := strings.NewReader("")
 	// Make a request against an unreachable endpoint.
@@ -247,6 +253,7 @@ func TestBadRoundTripDial(t *testing.T) {
 }
 
 func TestRoundTripReuseDatarace(t *testing.T) {
+	TestDaemon.Reset()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b := []byte(`200 - Nothing to see`)
 		w.WriteHeader(http.StatusOK)
@@ -280,6 +287,7 @@ func TestRoundTripReuseDatarace(t *testing.T) {
 }
 
 func TestRoundTripReuseTLSDatarace(t *testing.T) {
+	TestDaemon.Reset()
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b := []byte(`200 - Nothing to see`)
 		w.WriteHeader(http.StatusOK)
@@ -323,6 +331,7 @@ func TestRoundTripReuseTLSDatarace(t *testing.T) {
 }
 
 func TestRoundTripHttp2Datarace(t *testing.T) {
+	TestDaemon.Reset()
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b := []byte(`200 - Nothing to see`)
 		w.WriteHeader(http.StatusOK)

--- a/xray/context_test.go
+++ b/xray/context_test.go
@@ -40,6 +40,7 @@ func TestDetachContext(t *testing.T) {
 }
 
 func TestValidAnnotations(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	var err exception.MultiError
 	if e := AddAnnotation(ctx, "string", "str"); e != nil {
@@ -66,6 +67,7 @@ func TestValidAnnotations(t *testing.T) {
 }
 
 func TestInvalidAnnotations(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	type MyObject struct{}
 
@@ -78,6 +80,7 @@ func TestInvalidAnnotations(t *testing.T) {
 }
 
 func TestSimpleMetadata(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	var err exception.MultiError
 	if e := AddMetadata(ctx, "string", "str"); e != nil {
@@ -104,6 +107,7 @@ func TestSimpleMetadata(t *testing.T) {
 }
 
 func TestAddError(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, root := BeginSegment(context.Background(), "Test")
 	err := AddError(ctx, errors.New("New Error"))
 	assert.Nil(t, err)

--- a/xray/handler_test.go
+++ b/xray/handler_test.go
@@ -49,6 +49,7 @@ func TestNewDynamicSegmentNameFromEnv(t *testing.T) {
 }
 
 func TestHandlerWithContextForRootHandler(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, _ := ContextWithConfig(context.Background(), Config{
 		ServiceVersion: "1.0.0",
 	})
@@ -81,6 +82,7 @@ func TestHandlerWithContextForRootHandler(t *testing.T) {
 }
 
 func TestHandlerWithContextForNonRootHandler(t *testing.T) {
+	TestDaemon.Reset()
 	ctx, _ := ContextWithConfig(context.Background(), Config{
 		ServiceVersion: "1.0.0",
 	})
@@ -108,6 +110,7 @@ func TestHandlerWithContextForNonRootHandler(t *testing.T) {
 }
 
 func TestRootHandler(t *testing.T) {
+	TestDaemon.Reset()
 	// keep a sleep here because Reservoir allows a specified amount of `Take()`s per second.
 	time.Sleep(1 * time.Second)
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -137,6 +140,7 @@ func TestRootHandler(t *testing.T) {
 }
 
 func TestNonRootHandler(t *testing.T) {
+	TestDaemon.Reset()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/xray/lambda_test.go
+++ b/xray/lambda_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestLambdaSegmentEmit(t *testing.T) {
+	TestDaemon.Reset()
 	ctx := context.WithValue(context.Background(), LambdaTraceHeaderKey, "Root=fakeid; Parent=reqid; Sampled=1")
 	_, subseg := BeginSubsegment(ctx, "test-lambda")
 	subseg.Close(nil)

--- a/xray/sql_test.go
+++ b/xray/sql_test.go
@@ -83,73 +83,73 @@ func (s *sqlTestSuite) mockOracle(err error) {
 }
 
 func (s *sqlTestSuite) TestPasswordlessURL() {
-	s.mockDB("postgres://user@host:port/database")
+	s.mockDB("postgres://user@host:1234/database")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("postgres://user@host:port/database", s.db.url)
+	s.Equal("postgres://user@host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestPasswordURL() {
-	s.mockDB("postgres://user:password@host:port/database")
+	s.mockDB("postgres://user:password@host:1234/database")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("postgres://user@host:port/database", s.db.url)
+	s.Equal("postgres://user@host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestPasswordURLQuery() {
-	s.mockDB("postgres://host:port/database?password=password")
+	s.mockDB("postgres://host:1234/database?password=password")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("postgres://host:port/database", s.db.url)
+	s.Equal("postgres://host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestPasswordURLSchemaless() {
-	s.mockDB("user:password@host:port/database")
+	s.mockDB("user:password@host:1234/database")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("user@host:port/database", s.db.url)
+	s.Equal("user@host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestPasswordURLSchemalessUserlessQuery() {
-	s.mockDB("host:port/database?password=password")
+	s.mockDB("host:1234/database?password=password")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("host:port/database", s.db.url)
+	s.Equal("host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestWeirdPasswordURL() {
-	s.mockDB("user%2Fpassword@host:port/database")
+	s.mockDB("user%2Fpassword@host:1234/database")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("user@host:port/database", s.db.url)
+	s.Equal("user@host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestWeirderPasswordURL() {
-	s.mockDB("user/password@host:port/database")
+	s.mockDB("user/password@host:1234/database")
 	s.mockPSQL(nil)
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
 	s.Equal("", s.db.connectionString)
-	s.Equal("user@host:port/database", s.db.url)
+	s.Equal("user@host:1234/database", s.db.url)
 }
 
 func (s *sqlTestSuite) TestPasswordlessConnectionString() {

--- a/xray/util_test.go
+++ b/xray/util_test.go
@@ -85,6 +85,17 @@ func (td *Testdaemon) Recv() (*Segment, error) {
 	}
 }
 
+// Resets the daemon
+func (td *Testdaemon) Reset ()  {
+	for {
+		_, err := td.Recv()
+
+		if err != nil {
+			break
+		}
+	}
+}
+
 type XRayHeaders struct {
 	RootTraceID string
 	ParentID    string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Major Bugfix: Inconsistent test failures because of daemon sending incorrect data after 10-15 attempts
2. Fixed sql test cases by changing ports to numeric (recent change in Go)
3. Fixed test.yml (windows 9 and 10 environment set up)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
