### PR TITLE
go-mysql password sanitizing support

### DIFF
--- a/xray/sql.go
+++ b/xray/sql.go
@@ -281,13 +281,15 @@ func stripPasswords(dsn string) string {
 				buf.UnreadByte()
 			}
 		case '@':
-			isPassword = true
-			flush()
-			resLen := res.Len()
-			if resLen > 0 && res.Bytes()[resLen-1] == ':' {
-				res.Truncate(resLen - 1)
+			if strings.Contains(res.String(), ":") {
+				resLen := res.Len()
+				if resLen > 0 && res.Bytes()[resLen-1] == ':' {
+					res.Truncate(resLen - 1)
+				}
+				isPassword = true
+				flush()
+				res.WriteByte(c)
 			}
-			res.WriteByte(c)
 		}
 	}
 	inBraces = false

--- a/xray/sql.go
+++ b/xray/sql.go
@@ -280,6 +280,14 @@ func stripPasswords(dsn string) string {
 				inBraces = false
 				buf.UnreadByte()
 			}
+		case '@':
+			isPassword = true
+			flush()
+			resLen := res.Len()
+			if res.Bytes()[resLen-1] == ':' {
+				res.Truncate(resLen - 1)
+			}
+			res.WriteByte(c)
 		}
 	}
 	inBraces = false

--- a/xray/sql.go
+++ b/xray/sql.go
@@ -284,7 +284,7 @@ func stripPasswords(dsn string) string {
 			isPassword = true
 			flush()
 			resLen := res.Len()
-			if res.Bytes()[resLen-1] == ':' {
+			if resLen > 0 && res.Bytes()[resLen-1] == ':' {
 				res.Truncate(resLen - 1)
 			}
 			res.WriteByte(c)

--- a/xray/sql_go111_test.go
+++ b/xray/sql_go111_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+// +build go1.11
+
+package xray
+
+func (s *sqlTestSuite) TestMySQLPasswordConnectionString() {
+	s.mockDB("username:password@protocol(address:1234)/dbname?param=value")
+	s.mockMySQL(nil)
+	s.connect()
+
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
+	s.Equal("", s.db.url)
+}
+
+func (s *sqlTestSuite) TestMySQLPasswordlessConnectionString() {
+	s.mockDB("username@protocol(address:1234)/dbname?param=value")
+	s.mockMySQL(nil)
+	s.connect()
+
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
+	s.Equal("", s.db.url)
+}

--- a/xray/sql_go111_test.go
+++ b/xray/sql_go111_test.go
@@ -16,8 +16,14 @@ func (s *sqlTestSuite) TestMySQLPasswordConnectionString() {
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
-	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
-	s.Equal("", s.db.url)
+	if s.db.connectionString != "" {
+		s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
+		s.Equal("", s.db.url)
+	}
+	if s.db.url != "" {
+		s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.url)
+		s.Equal("", s.db.connectionString)
+	}
 }
 
 func (s *sqlTestSuite) TestMySQLPasswordlessConnectionString() {
@@ -26,6 +32,12 @@ func (s *sqlTestSuite) TestMySQLPasswordlessConnectionString() {
 	s.connect()
 
 	s.Require().NoError(s.mock.ExpectationsWereMet())
-	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
-	s.Equal("", s.db.url)
+	if s.db.connectionString != "" {
+		s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
+		s.Equal("", s.db.url)
+	}
+	if s.db.url != "" {
+		s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.url)
+		s.Equal("", s.db.connectionString)
+	}
 }

--- a/xray/sql_prego111_test.go
+++ b/xray/sql_prego111_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+// +build !go1.11
+
+package xray
+
+func (s *sqlTestSuite) TestMySQLPasswordConnectionStringPreGo111() {
+	s.mockDB("username:password@protocol(address:1234)/dbname?param=value")
+	s.mockMySQL(nil)
+	s.connect()
+
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("", s.db.connectionString)
+	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.url)
+}
+
+func (s *sqlTestSuite) TestMySQLPasswordlessConnectionStringPreGo111() {
+	s.mockDB("username@protocol(address:1234)/dbname?param=value")
+	s.mockMySQL(nil)
+	s.connect()
+
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("", s.db.connectionString)
+	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.url)
+}

--- a/xray/sql_test.go
+++ b/xray/sql_test.go
@@ -182,6 +182,16 @@ func (s *sqlTestSuite) TestSemicolonPasswordConnectionString() {
 	s.Equal("", s.db.url)
 }
 
+func (s *sqlTestSuite) TestMySQLConnectionString() {
+	s.mockDB("username:password@protocol(address:1234)/dbname?param=value")
+	s.mockMySQL(nil)
+	s.connect()
+
+	s.Require().NoError(s.mock.ExpectationsWereMet())
+	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
+	s.Equal("", s.db.url)
+}
+
 func (s *sqlTestSuite) TestPSQL() {
 	s.mockDB("")
 	s.mockPSQL(nil)

--- a/xray/sql_test.go
+++ b/xray/sql_test.go
@@ -182,16 +182,6 @@ func (s *sqlTestSuite) TestSemicolonPasswordConnectionString() {
 	s.Equal("", s.db.url)
 }
 
-func (s *sqlTestSuite) TestMySQLConnectionString() {
-	s.mockDB("username:password@protocol(address:1234)/dbname?param=value")
-	s.mockMySQL(nil)
-	s.connect()
-
-	s.Require().NoError(s.mock.ExpectationsWereMet())
-	s.Equal("username@protocol(address:1234)/dbname?param=value", s.db.connectionString)
-	s.Equal("", s.db.url)
-}
-
 func (s *sqlTestSuite) TestPSQL() {
 	s.mockDB("")
 	s.mockPSQL(nil)


### PR DESCRIPTION
*Issue #, if available:*
#131 and #160 but more general
Description of changes:
Adds a case to the `stripPasswords` function to cover the case for using the go-sql-driver/mysql (https://github.com/go-sql-driver/mysql#dsn-data-source-name). The current code does not support stripping the passwords from the default go-mysql DSN format:

The Data Source Name has a common format, like e.g. PEAR DB uses it, but without type-prefix (optional parts marked by squared brackets):

`[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]`

A DSN in its fullest form:

`username:password@protocol(address)/dbname?param=value`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
