### PR TITLE
Changed README instructions for go mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 
 ![Screenshot of the AWS X-Ray console](/images/example.png?raw=true)
 
-## Installing
+## Installing into GOPATH
 
 The AWS X-Ray SDK for Go is compatible with Go 1.9 and above.
 
 Install the SDK using the following command (The SDK's non-testing dependencies will be installed):
-Use `go get` to retrieve the SDK to add it to your `GOPATH` workspace, or your project's Go module dependencies (Go 1.11 and up):
+Use `go get` to retrieve the SDK to add it to your `GOPATH` workspace:
+
 ```
 go get github.com/aws/aws-xray-sdk-go
 ```
+
 To update the SDK, use `go get -u` to retrieve the latest version of the SDK.
 
 ```
@@ -25,7 +27,19 @@ If you also want to install SDK's testing dependencies. They can be installed us
 go get -u -t github.com/aws/aws-xray-sdk-go/...
 ```
 
-### Dep
+## Installing using Go Modules
+
+The X-Ray SDK for Go is currently in release candidate (RC) stage. The latest RC of the SDK is the recommended version and will be supported before the GA release of v1, which is tracked in this [issue](https://github.com/aws/aws-xray-sdk-go/issues/205).
+
+If you are using Go 1.11 and above, you can install the SDK using Go Modules. You must specify the latest RC version when installing the SDK, like so: 
+
+```
+go get github.com/aws/aws-xray-sdk-go@v1.0.0-rc.15
+```
+
+To get a different specific release version of the SDK use `@<tag>` in your `go get` command.
+
+## Installing using Dep
 If you are using Go 1.9 and above, you can also use [Dep](https://github.com/golang/dep) to add the SDK to your application's dependencies.
 Using Dep will help your application stay pinned to a specific version of the SDK.
 
@@ -34,11 +48,6 @@ To add the SDK to your application using Dep, run:
 ```
 dep ensure -add github.com/aws/aws-xray-sdk-go
 ```
-
-### Go Modules
-If you are using Go modules, your `go get` will default to the latest tagged release version of the SDK.
-To get a specific release version of the SDK use `@<tag>` in your `go get` command.
-
 
 ## Getting Help
 


### PR DESCRIPTION
*Issue #, if available:*
#205 

*Description of changes:*
Temporarily updates installation instructions for users of `go mod` to obtain the latest RC of the SDK. The new "Installing using go modules" section can be deleted (since instructions will be the same as installing into `GOPATH`) once v1 is GA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
