### PR TITLE
Fixed deadlock issue for non-reported segments.

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -286,13 +286,13 @@ func (seg *Segment) Close(err error) {
 		seg.addError(err)
 	}
 
-	seg.Unlock()
-
 	// If segment is dummy we return
 	if seg.Dummy {
+		seg.Unlock()
 		return
 	}
 
+	seg.Unlock()
 	seg.send()
 }
 

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -286,12 +286,13 @@ func (seg *Segment) Close(err error) {
 		seg.addError(err)
 	}
 
+	seg.Unlock()
+
 	// If segment is dummy we return
 	if seg.Dummy {
 		return
 	}
 
-	seg.Unlock()
 	seg.send()
 }
 


### PR DESCRIPTION
*Issue #, if available: https://github.com/aws/aws-xray-sdk-go/issues/222*

*Description of changes:*
A recent introduction if the `Dummy` property caused a function on `Segment` to return before the lock had been released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
