### PR TITLE
remove query string from url in http client http segment

### DIFF
--- a/xray/client.go
+++ b/xray/client.go
@@ -87,7 +87,7 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 
 		seg.GetHTTP().GetRequest().Method = r.Method
-		seg.GetHTTP().GetRequest().URL = getURLMinusQuery(*r.URL)
+		seg.GetHTTP().GetRequest().URL = stripQueryFromURL(*r.URL)
 
 		r.Header.Set(TraceIDHeaderKey, seg.DownstreamHeader().String())
 		seg.Unlock()
@@ -119,7 +119,7 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func getURLMinusQuery (u url.URL) string {
+func stripQueryFromURL(u url.URL) string {
 	u.RawQuery = ""
 	return u.String()
 }

--- a/xray/client.go
+++ b/xray/client.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptrace"
+	"net/url"
 	"strconv"
 
 	"github.com/aws/aws-xray-sdk-go/internal/logger"
@@ -86,7 +87,7 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 
 		seg.GetHTTP().GetRequest().Method = r.Method
-		seg.GetHTTP().GetRequest().URL = r.URL.String()
+		seg.GetHTTP().GetRequest().URL = getURLMinusQuery(*r.URL)
 
 		r.Header.Set(TraceIDHeaderKey, seg.DownstreamHeader().String())
 		seg.Unlock()
@@ -116,4 +117,9 @@ func (rt *roundtripper) RoundTrip(r *http.Request) (*http.Response, error) {
 		return err
 	})
 	return resp, err
+}
+
+func getURLMinusQuery (u url.URL) string {
+	u.RawQuery = ""
+	return u.String()
 }

--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -132,6 +132,52 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRoundTripWithQueryParameter(t *testing.T) {
+	ctx, td := NewTestDaemon()
+	defer td.Close()
+
+	const content = `200 - Nothing to see`
+	const responseContentLength = len(content)
+	const queryParam = `?key=value`
+
+
+	ch := make(chan XRayHeaders, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.String(), queryParam)
+		ch <- ParseHeadersForTest(r.Header)
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte(content)); err != nil {
+			panic(err)
+		}
+	}))
+	defer ts.Close()
+
+	client := Client(nil)
+
+	err := httpDoTest(ctx, client, http.MethodGet, ts.URL + queryParam, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	seg, err := td.Recv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	var subseg *Segment
+	if assert.NoError(t, json.Unmarshal(seg.Subsegments[0], &subseg)) {
+		assert.Equal(t, "remote", subseg.Namespace)
+		assert.Equal(t, http.MethodGet, subseg.HTTP.Request.Method)
+		assert.Equal(t, ts.URL, subseg.HTTP.Request.URL)
+		assert.Equal(t, http.StatusOK, subseg.HTTP.Response.Status)
+		assert.Equal(t, responseContentLength, subseg.HTTP.Response.ContentLength)
+		assert.False(t, subseg.Throttle)
+		assert.False(t, subseg.Error)
+		assert.False(t, subseg.Fault)
+	}
+	headers := <-ch
+	assert.Equal(t, headers.RootTraceID, seg.TraceID)
+}
+
 func TestRoundTripWithError(t *testing.T) {
 	ctx, td := NewTestDaemon()
 	defer td.Close()

--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -140,7 +140,6 @@ func TestRoundTripWithQueryParameter(t *testing.T) {
 	const responseContentLength = len(content)
 	const queryParam = `?key=value`
 
-
 	ch := make(chan XRayHeaders, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.String(), queryParam)
@@ -154,7 +153,7 @@ func TestRoundTripWithQueryParameter(t *testing.T) {
 
 	client := Client(nil)
 
-	err := httpDoTest(ctx, client, http.MethodGet, ts.URL + queryParam, nil)
+	err := httpDoTest(ctx, client, http.MethodGet, ts.URL+queryParam, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -457,7 +456,7 @@ func TestRoundTripReuseHTTP2Datarace(t *testing.T) {
 
 // Benchmarks
 func BenchmarkClient(b *testing.B) {
-	for i:=0; i<b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		Client(nil)
 	}
 }


### PR DESCRIPTION
*Issue #227 *

*Description of changes:*
Removes query string from the http.request.url in the subsegment created by xray.RoundTripper

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
