### PR TITLE
Fix typo (Metdata -> Metadata)

### DIFF
--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -105,3 +105,12 @@ func getMetadata(imdsURL string, client *http.Client, token string) (*http.Respo
 
 	return client.Do(req)
 }
+
+// Metdata is deprecated.
+// It will be removed in the future but kept only for backward compatibility.
+type Metdata struct {
+	AvailabilityZone string
+	ImageID          string
+	InstanceID       string
+	InstanceType     string
+}

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -106,8 +106,9 @@ func getMetadata(imdsURL string, client *http.Client, token string) (*http.Respo
 	return client.Do(req)
 }
 
-// Metdata is deprecated.
-// It will be removed in the future but kept only for backward compatibility.
+// Metdata represents IMDS response.
+//
+// Deprecated: Metdata exists for only backward compatibility.
 type Metdata struct {
 	AvailabilityZone string
 	ImageID          string

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -20,7 +20,7 @@ import (
 // Origin is the type of AWS resource that runs your application.
 const Origin = "AWS::EC2::Instance"
 
-type Metadata struct {
+type metadata struct {
 	AvailabilityZone string
 	ImageID          string
 	InstanceID       string
@@ -35,7 +35,7 @@ func Init() {
 }
 
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
-	var instanceData Metadata
+	var instanceData metadata
 	imdsURL := "http://169.254.169.254/latest/"
 
 	client := &http.Client{

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -108,7 +108,7 @@ func getMetadata(imdsURL string, client *http.Client, token string) (*http.Respo
 
 // Metdata represents IMDS response.
 //
-// Deprecated: Metdata exists for only backward compatibility.
+// Deprecated: Metdata exists only for backward compatibility.
 type Metdata struct {
 	AvailabilityZone string
 	ImageID          string

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -20,7 +20,7 @@ import (
 // Origin is the type of AWS resource that runs your application.
 const Origin = "AWS::EC2::Instance"
 
-type Metdata struct {
+type Metadata struct {
 	AvailabilityZone string
 	ImageID          string
 	InstanceID       string
@@ -35,7 +35,7 @@ func Init() {
 }
 
 func addPluginMetadata(pluginmd *plugins.PluginMetadata) {
-	var instanceData Metdata
+	var instanceData Metadata
 	imdsURL := "http://169.254.169.254/latest/"
 
 	client := &http.Client{

--- a/awsplugins/ec2/ec2_test.go
+++ b/awsplugins/ec2/ec2_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const metadata = `{
+const testMetadata = `{
   "accountId" : "123367104812",
   "architecture" : "x86_64",
   "availabilityZone" : "us-west-2a",
@@ -52,7 +52,7 @@ func TestIMDSv2Success(t *testing.T) {
 
 		assert.Equal(t, req.URL.String(), documentPath)
 		assert.Equal(t, req.Header.Get("X-aws-ec2-metadata-token"), "success")
-		_, _ = rw.Write([]byte(metadata))
+		_, _ = rw.Write([]byte(testMetadata))
 	}))
 
 	defer serverToken.Close()
@@ -69,7 +69,7 @@ func TestIMDSv2Success(t *testing.T) {
 	// successfully metadata fetch using IMDS v2
 	respMetadata, _ := getMetadata(serverMetadata.URL+"/", client, respToken)
 	ec2Metadata, _ := ioutil.ReadAll(respMetadata.Body)
-	assert.Equal(t, []byte(metadata), ec2Metadata)
+	assert.Equal(t, []byte(testMetadata), ec2Metadata)
 }
 
 func TestIMDSv2Failv1Success(t *testing.T) {
@@ -83,7 +83,7 @@ func TestIMDSv2Failv1Success(t *testing.T) {
 	serverMetadata := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 
 		assert.Equal(t, req.URL.String(), documentPath)
-		_, _ = rw.Write([]byte(metadata))
+		_, _ = rw.Write([]byte(testMetadata))
 	}))
 
 	defer serverToken.Close()
@@ -100,7 +100,7 @@ func TestIMDSv2Failv1Success(t *testing.T) {
 	// fallback to IMDSv1 and successfully metadata fetch using IMDSv1
 	respMetadata, _ := getMetadata(serverMetadata.URL+"/", client, respToken)
 	ec2Metadata, _ := ioutil.ReadAll(respMetadata.Body)
-	assert.Equal(t, []byte(metadata), ec2Metadata)
+	assert.Equal(t, []byte(testMetadata), ec2Metadata)
 }
 
 func TestIMDSv2Failv1Fail(t *testing.T) {
@@ -113,7 +113,7 @@ func TestIMDSv2Failv1Fail(t *testing.T) {
 	serverMetadata := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 
 		assert.Equal(t, req.URL.String(), documentPath)
-		_, _ = rw.Write([]byte(metadata))
+		_, _ = rw.Write([]byte(testMetadata))
 	}))
 
 	defer serverToken.Close()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`ec2.Metdata` type that introduced by #235 is maybe typo of `ec2.Metadata`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
