### PR TITLE
refresh messages changed to debug to reduce log noise

### DIFF
--- a/strategy/sampling/centralized.go
+++ b/strategy/sampling/centralized.go
@@ -221,7 +221,7 @@ func (ss *CentralizedStrategy) startRulePoller() {
 			if err := ss.refreshManifest(); err != nil {
 				logger.Debugf("Error occurred while refreshing sampling rules. %v", err)
 			} else {
-				logger.Info("Successfully fetched sampling rules")
+				logger.Debug("Successfully fetched sampling rules")
 			}
 		}
 	}()
@@ -413,7 +413,7 @@ func (ss *CentralizedStrategy) refreshTargets() (err error) {
 	if failed {
 		err = errors.New("error occurred updating sampling targets")
 	} else {
-		logger.Info("Successfully refreshed sampling targets")
+		logger.Debug("Successfully refreshed sampling targets")
 	}
 
 	// Set refresh flag if modifiedAt timestamp from remote is greater than ours.


### PR DESCRIPTION
Fixes #240 

When refreshing sampling rules or targets, this should be debug since it just creates noise in the logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
