### PR TITLE
Added example output of benchmark results

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,8 @@
 # Benchmark Instructions for AWS X-Ray Go SDK
 AWS X-Ray Go SDK introduced benchmarks to identify performance bottlenecks of AWS X-Ray Go SDK codebase. Moreover, benchmarks can be used to identify data races and locking issues. Below are the instructions on how to run AWS X-Ray Go SDK benchmarks using Go commands and makefile.
 
+An example of the benchmark output can be found [here](./results/1.0.0.md).
+
 ## Run all the benchmarks using Go Command
 ```
 go test -benchmem -run=^$$ -bench=. ./...

--- a/benchmark/results/1.0.0.md
+++ b/benchmark/results/1.0.0.md
@@ -1,0 +1,35 @@
+# Example Benchmark Results
+
+The below table contains a formatted output of the benchmarking results for v1.0.0 of the SDK. It was run on a m5.xlarge EC2 instance, with 16 GB of memory and 4 vCPUs.
+
+| Operation | Iterations | Latency | Memory | Allocs          |
+| --------------------------------------------------- | ------------- | ------------- | ------------- | ----------- |
+|BenchmarkGetDaemonEndpoints-4                       |3846729       |293 ns/op     |144 B/op      |5 allocs/op |
+|BenchmarkGetDaemonEndpointsFromEnv_DoubleParse-4      |784056       |1544 ns/op      |432 B/op       |14 allocs/op|
+|BenchmarkGetDaemonEndpointsFromEnv_SingleParse-4    |1000000000          |0.000009 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkGetDaemonEndpointsFromString-4           |1000000000          |0.000015 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkFromString-4     |2442208        |492 ns/op      |480 B/op        |4 allocs/op
+|BenchmarkWildcardMatch-4    |47175990         |25.1 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkDefaultFormattingStrategy_Error-4                   |676300       |1574 ns/op      |496 B/op        |4 allocs/op
+|BenchmarkDefaultFormattingStrategy_ExceptionFromError-4      |638359       |1875 ns/op      |408 B/op       |10 allocs/op
+|BenchmarkDefaultFormattingStrategy_Panic-4                   |269598       |4488 ns/op     |1344 B/op        |8 allocs/op
+|BenchmarkCentralizedManifest_putRule-4                |2163954        |556 ns/op      |416 B/op        |5 allocs/op
+|BenchmarkCentralizedStrategy_ShouldTrace-4           |1520000        |789 ns/op      |384 B/op       |11 allocs/op
+|BenchmarkNewCentralizedStrategy_refreshManifest-4     |2000916        |599 ns/op      |112 B/op        |2 allocs/op
+|BenchmarkCentralizedStrategy_refreshTargets-4         |8582516        |141 ns/op       |56 B/op        |2 allocs/op
+|BenchmarkCentralizedRule_Sample-4                     |6970968        |172 ns/op      |288 B/op        |5 allocs/op
+|BenchmarkNewLocalizedStrategyFromJSONBytes-4         |1000000000          |0.000005 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkCapture-4                          |465134       |2533 ns/op      |681 B/op       |12 allocs/op
+|BenchmarkClient-4                         |1000000000          |0.647 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkConfigure-4                       |5442780        |219 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkGetRecorder-4                    |100000000         |10.8 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkGetSegment-4                     |186037935          |6.45 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkDetachContext-4                  |18997809         |62.8 ns/op       |48 B/op        |1 allocs/op
+|BenchmarkAddAnnotation-4                  |13307188         |82.8 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkAddMetadata-4                    |12797424         |93.2 ns/op        |0 B/op        |0 allocs/op
+|BenchmarkDefaultEmitter_packSegments-4        |1531   |11728896 ns/op  |2721945 B/op    |50582 allocs/op
+|BenchmarkDefaultEmitter-4                 |178814       |6600 ns/op      |584 B/op       |17 allocs/op
+|BenchmarkHandler-4                        |4251     |274168 ns/op    |31603 B/op      |247 allocs/op
+|BenchmarkBeginSegment-4                   |64215      |20233 ns/op     |3264 B/op       |40 allocs/op
+|BenchmarkBeginSubsegment-4                |537710       |2412 ns/op      |674 B/op       |12 allocs/op
+|BenchmarkAddError-4                       |481357       |2784 ns/op      |931 B/op        |5 allocs/op


### PR DESCRIPTION
*Description of changes:*
Adding an example of benchmark output for 1.0.0 of the SDK for customers to reference as a very general baseline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
