### PR TITLE
Fixed a bug that caused a panic when AddError was called when the SDK was disabled

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -579,6 +579,11 @@ func (seg *Segment) AddMetadataToNamespace(namespace string, key string, value i
 
 // AddError allows adding an error to the segment.
 func (seg *Segment) AddError(err error) error {
+	// If SDK is disabled then return
+	if SdkDisabled() {
+		return nil
+	}
+
 	seg.Lock()
 	defer seg.Unlock()
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*

When I set the SDK to disabled and call the AddError function, I get the error `runtime error: invalid memory address or nil pointer dereference`.

This is because the function is called even though `seg.ParentSegment` does not exist in the following line.

https://github.com/kznrluk/aws-xray-sdk-go/blob/307d7d9d01e8e45cf7f1cb0d827796b00a415014/xray/segment.go#L598-L598

The other functions seem to be working correctly, but this one is not.

For the correct behavior, you need to make sure that SDKDisabled is False before the function reads `seg.ParentSegment`.

NOTE: When using the standard HTTP handler, this problem will not occur if the SDK is disabled, because the function will be returned early. Also, using `seg.Close()` will not cause the problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
