### PR TITLE
fix: replace segment name from env on BeginSegment

### DIFF
--- a/xray/handler.go
+++ b/xray/handler.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 
@@ -36,9 +35,6 @@ type FixedSegmentNamer struct {
 // If the AWS_XRAY_TRACING_NAME environment variable is set,
 // its value will override the provided name argument.
 func NewFixedSegmentNamer(name string) *FixedSegmentNamer {
-	if fName := os.Getenv("AWS_XRAY_TRACING_NAME"); fName != "" {
-		name = fName
-	}
 	return &FixedSegmentNamer{
 		FixedName: name,
 	}
@@ -63,9 +59,6 @@ type DynamicSegmentNamer struct {
 
 // NewDynamicSegmentNamer creates a new dynamic segment namer.
 func NewDynamicSegmentNamer(fallback string, recognized string) *DynamicSegmentNamer {
-	if dName := os.Getenv("AWS_XRAY_TRACING_NAME"); dName != "" {
-		fallback = dName
-	}
 	return &DynamicSegmentNamer{
 		FallbackName:    fallback,
 		RecognizedHosts: recognized,

--- a/xray/handler_test.go
+++ b/xray/handler_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,25 +25,10 @@ func TestNewFixedSegmentName(t *testing.T) {
 	assert.Equal(t, "test", n.FixedName)
 }
 
-func TestNewFixedSegmentNameFromEnv(t *testing.T) {
-	os.Setenv("AWS_XRAY_TRACING_NAME", "test_env")
-	n := NewFixedSegmentNamer("test")
-	assert.Equal(t, "test_env", n.FixedName)
-	os.Unsetenv("AWS_XRAY_TRACING_NAME")
-}
-
 func TestNewDynamicSegmentName(t *testing.T) {
 	n := NewDynamicSegmentNamer("test", "a/b/c")
 	assert.Equal(t, "test", n.FallbackName)
 	assert.Equal(t, "a/b/c", n.RecognizedHosts)
-}
-
-func TestNewDynamicSegmentNameFromEnv(t *testing.T) {
-	os.Setenv("AWS_XRAY_TRACING_NAME", "test_env")
-	n := NewDynamicSegmentNamer("test", "a/b/c")
-	assert.Equal(t, "test_env", n.FallbackName)
-	assert.Equal(t, "a/b/c", n.RecognizedHosts)
-	os.Unsetenv("AWS_XRAY_TRACING_NAME")
 }
 
 func TestHandlerWithContextForRootHandler(t *testing.T) {

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -70,10 +70,6 @@ func BeginFacadeSegment(ctx context.Context, name string, h *header.Header) (con
 
 // BeginSegment creates a Segment for a given name and context.
 func BeginSegment(ctx context.Context, name string) (context.Context, *Segment) {
-	if dName := os.Getenv("AWS_XRAY_TRACING_NAME"); dName != "" {
-		name = dName
-	}
-
 	return BeginSegmentWithSampling(ctx, name, nil, nil)
 }
 
@@ -82,6 +78,10 @@ func BeginSegmentWithSampling(ctx context.Context, name string, r *http.Request,
 	if SdkDisabled() {
 		seg := &Segment{}
 		return context.WithValue(ctx, ContextKey, seg), seg
+	}
+
+	if dName := os.Getenv("AWS_XRAY_TRACING_NAME"); dName != "" {
+		name = dName
 	}
 
 	seg := basicSegment(name, nil)

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -70,6 +70,9 @@ func BeginFacadeSegment(ctx context.Context, name string, h *header.Header) (con
 
 // BeginSegment creates a Segment for a given name and context.
 func BeginSegment(ctx context.Context, name string) (context.Context, *Segment) {
+	if dName := os.Getenv("AWS_XRAY_TRACING_NAME"); dName != "" {
+		name = dName
+	}
 
 	return BeginSegmentWithSampling(ctx, name, nil, nil)
 }

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -325,3 +325,11 @@ func BenchmarkIdGeneration_noOpFalse(b *testing.B) {
 	}
 	os.Unsetenv("AWS_XRAY_NOOP_ID")
 }
+
+func TestBeginSegmentNameFromEnv(t *testing.T) {
+	os.Setenv("AWS_XRAY_TRACING_NAME", "test_env")
+	_, n := BeginSegment(context.Background(), "test")
+	assert.Equal(t, "test_env", n.Name)
+	os.Unsetenv("AWS_XRAY_TRACING_NAME")
+	n.Close(nil)
+}


### PR DESCRIPTION
It is not clear from the [official documentation](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-go-configuration.html) that this variable is used only in HTTP situations:

```
Environment variables

You can use environment variables to configure the X-Ray SDK for Go. The SDK supports the following variables.

    AWS_XRAY_TRACING_NAME – Set the service name that the SDK uses for segments.
```

This PR applies the same logic so that the segment name is replaced by the environment variable `AWS_XRAY_TRACING_NAME`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
