### PR TITLE
Instead of creating new context append to outgoing context

### DIFF
--- a/xray/grpc.go
+++ b/xray/grpc.go
@@ -44,8 +44,7 @@ func UnaryClientInterceptor(clientInterceptorOptions ...GrpcOption) grpc.UnaryCl
 				return errors.New("failed to record gRPC transaction: segment cannot be found")
 			}
 
-			md := metadata.Pairs(TraceIDHeaderKey, seg.DownstreamHeader().String())
-			ctx = metadata.NewOutgoingContext(ctx, md)
+			ctx = metadata.AppendToOutgoingContext(ctx, TraceIDHeaderKey, seg.DownstreamHeader().String())
 
 			seg.Lock()
 			seg.Namespace = "remote"

--- a/xray/grpc_test.go
+++ b/xray/grpc_test.go
@@ -370,8 +370,7 @@ func TestUnaryServerAndClientInterceptor(t *testing.T) {
 				WithSegmentNamer(NewFixedSegmentNamer("test")))),
 	)
 	client, closeFunc := newGrpcClient(context.Background(), t, lis, grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		md := metadata.Pairs(TraceIDHeaderKey, "Root=fakeid; Parent=reqid; Sampled=1")
-		ctx = metadata.NewOutgoingContext(ctx, md)
+		ctx = metadata.AppendToOutgoingContext(ctx, TraceIDHeaderKey, "Root=fakeid; Parent=reqid; Sampled=1")
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}))
 	defer closeFunc()


### PR DESCRIPTION
For example: when setting authorization headers to an
outgoing context these will be removed when using
new context. By appending these stay in the outgoing
context

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
