### PR TITLE
fix: memory leak fasthttp handler

### DIFF
--- a/xray/fasthttp.go
+++ b/xray/fasthttp.go
@@ -1,6 +1,7 @@
 package xray
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -28,7 +29,9 @@ func NewFastHTTPInstrumentor(cfg *Config) FastHTTPHandler {
 // Handler wraps the provided fasthttp.RequestHandler
 func (h *fasthttpHandler) Handler(sn SegmentNamer, handler fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
+		auxCtx := context.Background()
 		if h.cfg != nil {
+			auxCtx = context.WithValue(context.Background(), fasthttpContextConfigKey, h.cfg)
 			ctx.SetUserValue(fasthttpContextConfigKey, h.cfg)
 		}
 
@@ -42,7 +45,7 @@ func (h *fasthttpHandler) Handler(sn SegmentNamer, handler fasthttp.RequestHandl
 			return
 		}
 
-		_, seg := NewSegmentFromHeader(ctx, name, req, traceHeader)
+		_, seg := NewSegmentFromHeader(auxCtx, name, req, traceHeader)
 		defer seg.Close(nil)
 
 		ctx.SetUserValue(fasthttpContextKey, seg)


### PR DESCRIPTION
We can't use `fasthttp.RequestCtx` in `NewSegmentFromHeader`, this generated an infinite wait in [xray/segment.go#L135](https://github.com/aws/aws-xray-sdk-go/blob/7446e854f1b2b9e0f2846cd33045abf4896dc0c8/xray/segment.go#L135), because `fasthttp.RequestCtx.Done()` is not called after finishing the request.

The solution was to create a new context to pass to `NewSegmentFromHeader`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.