### PR TITLE
Use grpc.SetHeader instead of grpc.SendHeader

### DIFF
--- a/xray/grpc.go
+++ b/xray/grpc.go
@@ -125,7 +125,7 @@ func UnaryServerInterceptor(serverInterceptorOptions ...GrpcOption) grpc.UnarySe
 		}
 		recordContentLength(seg, resp)
 		if headerErr := addResponseTraceHeader(ctx, seg, traceHeader); headerErr != nil {
-			logger.Debug("fail to send the grpc trace header")
+			logger.Debug("fail to set the grpc trace header")
 		}
 
 		return resp, err
@@ -181,7 +181,7 @@ func addResponseTraceHeader(ctx context.Context, seg *Segment, incomingTraceHead
 	headers := metadata.New(map[string]string{
 		TraceIDHeaderKey: respHeader.String(),
 	})
-	return grpc.SendHeader(ctx, headers)
+	return grpc.SetHeader(ctx, headers)
 }
 
 func inferServiceName(fullMethodName string) string {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have a gRPC unary server interceptor that sends header metadata to a client:

```go
func MyUnaryServerInterceptor(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
	resp, err := handler(ctx, req)
	if e := grpc.SetHeader(ctx, metadata.Pairs("foo", "bar")); e != nil {
		fmt.Println(e)
	}
	return handler(ctx, req)
}
```

When we use this interceptor along with the interceptor provided by xray.UnaryServerInterceptor 

```
server := grpc.NewServer(grpc.ChainUnaryInterceptor(MyUnaryServerInterceptor, xray.UnaryServerInterceptor()))
```

[grpc.SetHeader](https://pkg.go.dev/google.golang.org/grpc#SetHeader) in MyUnaryServerInterceptor returns the following [error](https://github.com/grpc/grpc-go/blob/4faa31f0a5809a5064ee128c9d855c0bedc1c783/internal/transport/transport.go#L425):

```
transport: the stream is done or WriteHeader was already called
```

The interceptor provided by xray.UnaryServerInterceptor calls [grpc.SendHeader](https://pkg.go.dev/google.golang.org/grpc#SendHeader), so the header is already sent when grpc.SetHeader is called.

This change should allow MyUnaryServerInterceptor to set header metadata.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
