### PR TITLE
feat: added segment EndTime check on close to support VirtualSegments…

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -347,7 +347,9 @@ func (seg *Segment) Close(err error) {
 	} else {
 		logger.Debugf("Closing segment named %s", seg.Name)
 	}
-	seg.EndTime = float64(time.Now().UnixNano()) / float64(time.Second)
+	if seg.EndTime == 0 {
+		seg.EndTime = float64(time.Now().UnixNano()) / float64(time.Second)
+	}
 	seg.InProgress = false
 
 	if err != nil {


### PR DESCRIPTION
…(SNS-SQS fanout trace recover)

*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-go/issues/321

*Description of changes:*
When event is sent to SNS from awslib wrapped with xray using WithContext, XRAY adds TraceHeader X-Amzn-Trace-Id.
Current it is not supported by AWS Lambda and xray library to automatically recover the TraceHeader and assign it as Parent SegmentID for the current Runtime (Lambda), etc. It is possible to recover trace header manually, create new Segment and assign TraceHeader SegmentID as ParentID for current segment. This will work for SQS integration and xray propagation scenario.

But in case if you are using SNS - to - SQS fanout: SNS propagates xray TraceHeader, but nor SNS nor SQS create Segment is XRAY. For such scenario it is possible to receive TraceHeader in SQS event. This TraceHeader is linked to SNS Service and its segments. SQS event contains information that can be used to create SQS Virtual segment (there is information in SQSEvent with metrics about both SNS and SQS timing, and based on them we can create exact startTime and endTime for SQS Virtual segment), map it to SNS pre-fanout Segment and fully recreate the trace chain. All further Segments in the current context will be mapped to SQS VirtualSegment.

The problem is that Xray lib automatically updates EndTime on Segment Close operation, which will make Time of VirtualSegment incorrect (with endTime set to NOW always).

Propose to automaticaly udpate EndTime only when it is not set, allowing to create Virtual segments for scenarios like SNS-SQS VirtualSegment fanout, etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
