### PR TITLE
xray: Don't leak goroutines on segment start

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -130,17 +130,19 @@ func BeginSegmentWithSampling(ctx context.Context, name string, r *http.Request,
 		}
 	}
 
-	if ctx.Done() != nil {
-		go func() {
-			<-ctx.Done()
-			seg.handleContextDone()
-		}()
-	}
-
 	// check whether segment is dummy or not based on sampling decision
 	if !seg.ParentSegment.Sampled {
 		seg.Dummy = true
 	}
+
+	// create a new context to close it on segment close;
+	// this makes sure the closing of the segment won't affect the client's code, that uses the returned context
+	ctx1, cancelCtx := context.WithCancel(ctx)
+	seg.cancelCtx = cancelCtx
+	go func() {
+		<-ctx1.Done()
+		seg.handleContextDone()
+	}()
 
 	// generates segment and trace id based on sampling decision and AWS_XRAY_NOOP_ID env variable
 	idGeneration(seg)
@@ -360,8 +362,15 @@ func (seg *Segment) Close(err error) {
 		return
 	}
 
+	cancelSegCtx := seg.cancelCtx
+
 	seg.Unlock()
 	seg.send()
+
+	// makes sure the goroutine, that waits for possible top-level context cancellation gets closed on segment close
+	if cancelSegCtx != nil {
+		cancelSegCtx()
+	}
 }
 
 // CloseAndStream closes a subsegment and sends it.

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -9,6 +9,7 @@
 package xray
 
 import (
+	"context"
 	"encoding/json"
 	"sync"
 
@@ -29,6 +30,9 @@ type Segment struct {
 	Emitted          bool           `json:"-"`
 	IncomingHeader   *header.Header `json:"-"`
 	ParentSegment    *Segment       `json:"-"` // The root of the Segment tree, the parent Segment (not Subsegment).
+
+	// cancels the context bound to this Segment, after Segment is closed
+	cancelCtx context.CancelFunc
 
 	// Required
 	TraceID   string  `json:"trace_id,omitempty"`

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -146,7 +146,9 @@ func TestParentSegmentTotalCount(t *testing.T) {
 }
 
 func TestSegment_Close(t *testing.T) {
-	ctx, seg := BeginSegment(context.Background(), "Segment")
+	ctx, td := NewTestDaemon()
+	defer td.Close()
+	ctx, seg := BeginSegment(ctx, "test")
 	seg.Close(nil)
 
 	// for backwards compatibility, closing the Segment should not cancel the returned Context

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -145,6 +145,14 @@ func TestParentSegmentTotalCount(t *testing.T) {
 	assert.Equal(t, 4*uint32(n), seg.ParentSegment.totalSubSegments, "totalSubSegments count should be correctly registered on the parent segment")
 }
 
+func TestSegment_Close(t *testing.T) {
+	ctx, seg := BeginSegment(context.Background(), "Segment")
+	seg.Close(nil)
+
+	// for backwards compatibility, closing the Segment should not cancel the returned Context
+	assert.NoError(t, ctx.Err())
+}
+
 func TestSegment_isDummy(t *testing.T) {
 	ctx, root := BeginSegment(context.Background(), "Segment")
 	ctxSubSeg1, subSeg1 := BeginSubsegment(ctx, "Subsegment1")


### PR DESCRIPTION
*Issue #, if available:*
This is a follow-up for https://github.com/aws/aws-xray-sdk-go/issues/51 and https://github.com/aws/aws-xray-sdk-go/pull/156

*Description of changes:*
https://github.com/aws/aws-xray-sdk-go/pull/156 has fixed a leak caused by the use of `context.Background()` with `xray.BeginSegmentWithSampling`. This won't work if a service's background job, uses a context, whose cancellation is bound to service's life-time. E.g. consider the following code:

```go
func main() {
	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
	defer stop()

	ticker := time.NewTicker(time.Minute)
	defer ticket.Stop()
	for {
		select {
		case <-ticker.C:
			_, seg := xray.BeginSegment(ctx, "")  // 👈 spawns a goroutine that never stops
			// do something
			seg.Close(nil)
		case <-ctx.Done():
			break
		}
	}
}
```

This PR aims at fixing the issue by making sure the goroutine, that `xray.BeginSegment` spawns will be stopped after the segment gets closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
