### PR TITLE
fix: routine leak for dummy segments

### DIFF
--- a/xray/segment.go
+++ b/xray/segment.go
@@ -136,14 +136,17 @@ func BeginSegmentWithSampling(ctx context.Context, name string, r *http.Request,
 		seg.Dummy = true
 	}
 
-	// create a new context to close it on segment close;
-	// this makes sure the closing of the segment won't affect the client's code, that uses the returned context
-	ctx1, cancelCtx := context.WithCancel(ctx)
-	seg.cancelCtx = cancelCtx
-	go func() {
-		<-ctx1.Done()
-		seg.handleContextDone()
-	}()
+	// don't allocate resources for dummy segments
+	if !seg.Dummy {
+		// create a new context to close it on segment close;
+		// this makes sure the closing of the segment won't affect the client's code, that uses the returned context
+		ctx1, cancelCtx := context.WithCancel(ctx)
+		seg.cancelCtx = cancelCtx
+		go func() {
+			<-ctx1.Done()
+			seg.handleContextDone()
+		}()
+	}
 
 	// generates segment and trace id based on sampling decision and AWS_XRAY_NOOP_ID env variable
 	idGeneration(seg)


### PR DESCRIPTION
Issue [364](https://github.com/aws/aws-xray-sdk-go/issues/364)

 If segment is dummy don't create go routine for context cancelation handling


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
