### PR TITLE
Strip X-Amz-Security-Token from SQL URIs

### DIFF
--- a/xray/sql_context.go
+++ b/xray/sql_context.go
@@ -336,9 +336,10 @@ func newDBAttribute(ctx context.Context, driverName string, d driver.Driver, con
 			u.User = url.User(uname)
 		}
 
-		// Strip password from query parameters
+		// Strip password and X-Amz-Security-Token (present in RDS IAM authentication) from query parameters
 		q := u.Query()
 		q.Del("password")
+		q.Del("X-Amz-Security-Token")
 		u.RawQuery = q.Encode()
 
 		// In the case of known DSL sub segment name will be dbname@host

--- a/xray/sqlcontext_test.go
+++ b/xray/sqlcontext_test.go
@@ -129,6 +129,16 @@ func TestDSN(t *testing.T) {
 			str:  "odbc:server=localhost;user id=sa;otherthing=thing",
 			name: "test database",
 		},
+		{
+			dsn:  "postgres://host:5432/database?X-Amz-Security-Token=token",
+			url:  "postgres://host:5432/database",
+			name: "test database@host",
+		},
+		{
+			dsn:  "host:5432/database?X-Amz-Security-Token=token",
+			url:  "host:5432/database",
+			name: "test database@host",
+		},
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In addition to `password`, I propose stripping the `X-Amz-Security-Token` param from the connection string as this is present in connections that use [RDS / Aurora IAM Authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) and could lead to exposure of the short-lived credentials.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
