### PR TITLE
Make AWS SDK v1 and v2 instrumentation examples more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ func main() {
 	doSomething(output)
 }
 ```
-*Segment creation is not necessary in environments where segments are bootstrapped automatically (e.g. AWS Lambda)*
+*Segment creation is not necessary in AWS Lambda functions, where segments are created automatically*
 
 **AWS SDK V2 Instrumentation**
 
@@ -262,7 +262,7 @@ func main() {
 	}
 }
 ```
-*Segment creation is not necessary in environments where segments are bootstrapped automatically (e.g. AWS Lambda)*
+*Segment creation is not necessary in AWS Lambda functions, where segments are created automatically*
 
 **S3**
 

--- a/README.md
+++ b/README.md
@@ -208,21 +208,21 @@ func getExample(ctx context.Context) ([]byte, error) {
 
 ```go
 func main() {
-  // Create a segment
-  ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV1_Dynamodb")
-  defer root.Close(nil)
+	// Create a segment
+	ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV1_Dynamodb")
+	defer root.Close(nil)
 
-  sess := session.Must(session.NewSession())
-  dynamo := dynamodb.New(sess)
-  // Instrumenting with AWS SDK v1:
-  // Wrap the client object with the xray.AWS()
-  xray.AWS(dynamo.Client)
-  // Use the withContext version of the ListTables call method
-  output := dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
-  doSomething(output)
+	sess := session.Must(session.NewSession())
+	dynamo := dynamodb.New(sess)
+	// Instrumenting with AWS SDK v1:
+	// Wrap the client object with the xray.AWS()
+	xray.AWS(dynamo.Client)
+	// Use the withContext version of the ListTables call method
+	output := dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
+	doSomething(output)
 }
 ```
-*Segment creation is not necessary in environments where segments are boostrapped automatically (e.g. AWS Lambda)*
+*Segment creation is not necessary in environments where segments are bootstrapped automatically (e.g. AWS Lambda)*
 
 **AWS SDK V2 Instrumentation**
 
@@ -230,39 +230,39 @@ func main() {
 package main
 
 import (
-  "context"
-  "log"
+	"context"
+	"log"
 
-  "github.com/aws/aws-sdk-go-v2/aws"
-  "github.com/aws/aws-sdk-go-v2/config"
-  "github.com/aws/aws-sdk-go-v2/service/dynamodb"
-  "github.com/aws/aws-xray-sdk-go/instrumentation/awsv2"
-  "github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-xray-sdk-go/instrumentation/awsv2"
+	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
 func main() {
-  // Create a segment
-  ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV2_Dynamodb")
-  defer root.Close(nil)
-
-  cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-2"))
-  if err != nil {
-    log.Fatalf("unable to load SDK config, %v", err)
-  }
-  // Instrumenting AWS SDK v2
-  awsv2.AWSV2Instrumentor(&cfg.APIOptions)
-  // Using the Config value, create the DynamoDB client
-  svc := dynamodb.NewFromConfig(cfg)
-  // Build the request with its input parameters
-  _, err = svc.ListTables(ctx, &dynamodb.ListTablesInput{
-    Limit: aws.Int32(5),
-  })
-  if err != nil {
-    log.Fatalf("failed to list tables, %v", err)
-  }
+	// Create a segment
+	ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV2_Dynamodb")
+	defer root.Close(nil)
+  
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-2"))
+	if err != nil {
+		log.Fatalf("unable to load SDK config, %v", err)
+	}
+	// Instrumenting AWS SDK v2
+	awsv2.AWSV2Instrumentor(&cfg.APIOptions)
+	// Using the Config value, create the DynamoDB client
+	svc := dynamodb.NewFromConfig(cfg)
+	// Build the request with its input parameters
+	_, err = svc.ListTables(ctx, &dynamodb.ListTablesInput{
+		Limit: aws.Int32(5),
+	})
+	if err != nil {
+		log.Fatalf("failed to list tables, %v", err)
+	}
 }
 ```
-*Segment creation is not necessary in environments where segments are boostrapped automatically (e.g. AWS Lambda)*
+*Segment creation is not necessary in environments where segments are bootstrapped automatically (e.g. AWS Lambda)*
 
 **S3**
 

--- a/README.md
+++ b/README.md
@@ -208,21 +208,21 @@ func getExample(ctx context.Context) ([]byte, error) {
 
 ```go
 func main() {
-	// Create a segment
-	ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV1_Dynamodb")
-	defer root.Close(nil)
+  // Create a segment
+  ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV1_Dynamodb")
+  defer root.Close(nil)
 
-	sess := session.Must(session.NewSession())
-	dynamo := dynamodb.New(sess)
-	// Instrumenting with AWS SDK v1:
-	// Wrap the client object with the xray.AWS()
-	xray.AWS(dynamo.Client)
-	// Use the withContext version of the ListTables call method
-	output := dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
-	doSomething(output)
+  sess := session.Must(session.NewSession())
+  dynamo := dynamodb.New(sess)
+  // Instrumenting with AWS SDK v1:
+  // Wrap the client object with `xray.AWS()`
+  xray.AWS(dynamo.Client)
+  // Use the `-WithContext` version of the `ListTables` method
+  output := dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
+  doSomething(output)
 }
 ```
-*Segment creation is not necessary in AWS Lambda functions, where segments are created automatically*
+*Segment creation is not necessary in an AWS Lambda function, where the segment is created automatically*
 
 **AWS SDK V2 Instrumentation**
 
@@ -262,7 +262,7 @@ func main() {
 	}
 }
 ```
-*Segment creation is not necessary in AWS Lambda functions, where segments are created automatically*
+*Segment creation is not necessary in an AWS Lambda function, where the segment is created automatically*
 
 **S3**
 

--- a/README.md
+++ b/README.md
@@ -196,22 +196,33 @@ func main() {
 
 ```go
 func getExample(ctx context.Context) ([]byte, error) {
-    resp, err := ctxhttp.Get(ctx, xray.Client(nil), "https://aws.amazon.com/")
-    if err != nil {
-      return nil, err
-    }
-    return ioutil.ReadAll(resp.Body)
+  resp, err := ctxhttp.Get(ctx, xray.Client(nil), "https://aws.amazon.com/")
+  if err != nil {
+    return nil, err
+  }
+  return ioutil.ReadAll(resp.Body)
 }
 ```
 
 **AWS SDK Instrumentation**
 
 ```go
-sess := session.Must(session.NewSession())
-dynamo := dynamodb.New(sess)
-xray.AWS(dynamo.Client)
-dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
+func main() {
+  // Create a segment
+  ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV1_Dynamodb")
+  defer root.Close(nil)
+
+  sess := session.Must(session.NewSession())
+  dynamo := dynamodb.New(sess)
+  // Instrumenting with AWS SDK v1:
+  // Wrap the client object with the xray.AWS()
+  xray.AWS(dynamo.Client)
+  // Use the withContext version of the ListTables call method
+  output := dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
+  doSomething(output)
+}
 ```
+*Segment creation is not necessary in environments where segments are boostrapped automatically (e.g. AWS Lambda)*
 
 **AWS SDK V2 Instrumentation**
 
@@ -219,36 +230,39 @@ dynamo.ListTablesWithContext(ctx, &dynamodb.ListTablesInput{})
 package main
 
 import (
-	"context"
-	"log"
+  "context"
+  "log"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-xray-sdk-go/instrumentation/awsv2"
-	"github.com/aws/aws-xray-sdk-go/xray"
+  "github.com/aws/aws-sdk-go-v2/aws"
+  "github.com/aws/aws-sdk-go-v2/config"
+  "github.com/aws/aws-sdk-go-v2/service/dynamodb"
+  "github.com/aws/aws-xray-sdk-go/instrumentation/awsv2"
+  "github.com/aws/aws-xray-sdk-go/xray"
 )
 
 func main() {
-	ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV2_Dynamodb")
-	defer root.Close(nil)
-	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-2"))
-	if err != nil {
-		log.Fatalf("unable to load SDK config, %v", err)
-	}
-	// Instrumenting AWS SDK v2
-	awsv2.AWSV2Instrumentor(&cfg.APIOptions)
-	// Using the Config value, create the DynamoDB client
-	svc := dynamodb.NewFromConfig(cfg)
-	// Build the request with its input parameters
-	_, err = svc.ListTables(ctx, &dynamodb.ListTablesInput{
-		Limit: aws.Int32(5),
-	})
-	if err != nil {
-		log.Fatalf("failed to list tables, %v", err)
-	}
+  // Create a segment
+  ctx, root := xray.BeginSegment(context.TODO(), "AWSSDKV2_Dynamodb")
+  defer root.Close(nil)
+
+  cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-2"))
+  if err != nil {
+    log.Fatalf("unable to load SDK config, %v", err)
+  }
+  // Instrumenting AWS SDK v2
+  awsv2.AWSV2Instrumentor(&cfg.APIOptions)
+  // Using the Config value, create the DynamoDB client
+  svc := dynamodb.NewFromConfig(cfg)
+  // Build the request with its input parameters
+  _, err = svc.ListTables(ctx, &dynamodb.ListTablesInput{
+    Limit: aws.Int32(5),
+  })
+  if err != nil {
+    log.Fatalf("failed to list tables, %v", err)
+  }
 }
 ```
+*Segment creation is not necessary in environments where segments are boostrapped automatically (e.g. AWS Lambda)*
 
 **S3**
 


### PR DESCRIPTION
Addresses issue https://github.com/aws/aws-xray-sdk-go/issues/368

*Description of changes:*
The instrumentation example for AWS SDK v1 did not include segment creation while the example for AWS SDK v2 did include segment creation. This made it seem as if segment creation is necessary in one version and not in the other, which is not the case.

Both instrumentation examples are now made to both create a segment, with a disclaimer that segment creation may not be necessary when segments are bootstrapped automatically.

Tabs are also changed to double spaces for more consistency as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
