### PR TITLE
Add check on existing segment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/xray/grpc.go
+++ b/xray/grpc.go
@@ -38,8 +38,15 @@ func UnaryClientInterceptor(clientInterceptorOptions ...GrpcOption) grpc.UnaryCl
 		if option.config != nil {
 			ctx = context.WithValue(ctx, RecorderContextKey{}, option.config)
 		}
+
+		seg := GetSegment(ctx)
+		if seg == nil {
+			ctx, seg = BeginSegment(ctx, segmentName)
+		}
+		defer seg.Close(nil)
+
 		return Capture(ctx, segmentName, func(ctx context.Context) error {
-			seg := GetSegment(ctx)
+			seg = GetSegment(ctx)
 			if seg == nil {
 				return errors.New("failed to record gRPC transaction: segment cannot be found")
 			}

--- a/xray/grpc_test.go
+++ b/xray/grpc_test.go
@@ -162,10 +162,11 @@ func TestGrpcUnaryClientInterceptor(t *testing.T) {
 			ctx, td := NewTestDaemon()
 			defer td.Close()
 
+			ctx2, root := BeginSegment(ctx, "Test")
 			var err error
 			if tc.isTestForSuccessResponse() {
 				_, err = client.Ping(
-					ctx,
+					ctx2,
 					&pb.PingRequest{
 						Value:       "something",
 						SleepTimeMs: 9999,
@@ -174,10 +175,11 @@ func TestGrpcUnaryClientInterceptor(t *testing.T) {
 				require.NoError(t, err)
 			} else {
 				_, err = client.PingError(
-					ctx,
+					ctx2,
 					&pb.PingRequest{Value: "something", ErrorCodeReturned: uint32(tc.responseErrorStatusCode)})
 				require.Error(t, err)
 			}
+			root.Close(nil)
 
 			seg, err := td.Recv()
 			require.NoError(t, err)


### PR DESCRIPTION
*Issue #, if available:*

<img width="938" alt="Снимок экрана 2022-08-17 в 17 25 25" src="https://user-images.githubusercontent.com/93581734/185159593-e344189d-2b9d-4324-bf7a-6bd626080c14.png">

Get panic when don't init new segment in grpc handler

*Description of changes:*

With this fix we won't get panic if forget to begin new segment in grpc handler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
