### PR TITLE
Change workflow to use go v1.9 rather than v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         go:
           - '1.16'
           - '1.17'
-          - '1'
+          - '1.9'
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1


### PR DESCRIPTION
*Issue #, if available:*
Workflow unit tests are failing in environments (windows-latest, 1) and (macos-latest, 1).

*Description of changes:*
Since the AWS X-Ray SDK for Go is compatible with Go v1.9 and above, remove the unit tests for Go v1 and use Go v1.9


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
