### PR TITLE
Convert to 16 byte representation of localhost in Unit Test if not already

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want additional features when tracing your Go applications, please [open 
 
 ## Installing into GOPATH
 
-The AWS X-Ray SDK for Go is compatible with Go 1.9 and above.
+The AWS X-Ray SDK for Go is compatible with Go 1.16 and above.
 
 Install the SDK using the following command (The SDK's non-testing dependencies will be installed):
 Use `go get` to retrieve the SDK to add it to your `GOPATH` workspace:

--- a/daemoncfg/daemon_config_test.go
+++ b/daemoncfg/daemon_config_test.go
@@ -242,6 +242,14 @@ func TestGetDaemonEndpointsForHostname1(t *testing.T) { // parsing hostname - si
 	tcpEndpt, _ := resolveTCPAddr(tcpAddr)
 	dEndpt, _ := GetDaemonEndpointsFromString("localhost:2000")
 
+	// Keep dEndpt.UDPAddr.IP as the IPv6 representation of an IPv4 address
+	if (len(dEndpt.UDPAddr.IP) == 4) {
+		dEndpt.UDPAddr.IP = dEndpt.UDPAddr.IP.To16()
+	}
+	if (len(dEndpt.TCPAddr.IP) == 4) {
+		dEndpt.TCPAddr.IP = dEndpt.TCPAddr.IP.To16()
+	}
+
 	assert.Equal(t, dEndpt.UDPAddr, udpEndpt)
 	assert.Equal(t, dEndpt.TCPAddr, tcpEndpt)
 }
@@ -258,6 +266,14 @@ func TestGetDaemonEndpointsForHostname3(t *testing.T) { // parsing hostname - do
 	udpEndpt, _ := resolveUDPAddr(udpAddr)
 	tcpEndpt, _ := resolveTCPAddr(tcpAddr)
 	dEndpt, _ := GetDaemonEndpointsFromString("tcp:localhost:2000 udp:localhost:2000")
+
+	// Keep dEndpt.UDPAddr.IP as the IPv6 representation of an IPv4 address
+	if (len(dEndpt.UDPAddr.IP) == 4) {
+		dEndpt.UDPAddr.IP = dEndpt.UDPAddr.IP.To16()
+	}
+	if (len(dEndpt.TCPAddr.IP) == 4) {
+		dEndpt.TCPAddr.IP = dEndpt.TCPAddr.IP.To16()
+	}
 
 	assert.Equal(t, dEndpt.UDPAddr, udpEndpt)
 	assert.Equal(t, dEndpt.TCPAddr, tcpEndpt)


### PR DESCRIPTION
*Issue #, if available:*
Unit tests starting failing in Go v1.20
https://github.com/aws/aws-xray-sdk-go/actions/runs/4198915049/jobs/7283153601

This is due to the Assertion of the TestGetDaemonEndpointsForHostname1 test, which ends up checking if the following equates:
>resolveUDPAddr("localhost:2000") == resolveUDPAddr("127.0.0.1:2000")

In Go v1.19 and before, resolveUDPAddr("localhost:2000") returns an IP with a a 16-byte representation of the 4 byte localhost, which is `0x7f, 0x0, 0x0, 0x1` (127.0.0.1) AND prepended with `::FFFF:`
>0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x7f, 0x0, 0x0, 0x1

However in Go v1.20 this will return the 4 byte representation WITHOUT being prepended with `::FFFF:`
>0x7f, 0x0, 0x0, 0x1

*Description of changes:*
Convert the 4 byte representation of localhost to 16 byte if not already.
Update Readme to state that the SDK is compatible with Go 1.16 and above. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
