### PR TITLE
Remove tests for older Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           - windows-latest
           - macos-latest
         go:
-          - '1.16'
-          - '1.17'
+          - '1.19'
+          - '1.20'
           - '1'
     steps:
       - name: Set up Go ${{ matrix.go }}
@@ -45,7 +45,7 @@ jobs:
         os:
           - ubuntu-latest
         go:
-          - '1.17'
+          - '1.20'
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want additional features when tracing your Go applications, please [open 
 
 ## Installing into GOPATH
 
-The AWS X-Ray SDK for Go is compatible with Go 1.16 and above.
+The AWS X-Ray SDK for Go is compatible with Go 1.19 and above.
 
 Install the SDK using the following command (The SDK's non-testing dependencies will be installed):
 Use `go get` to retrieve the SDK to add it to your `GOPATH` workspace:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-xray-sdk-go
 
-go 1.18
+go 1.20
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/integration-tests/distributioncheck/go.mod
+++ b/integration-tests/distributioncheck/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.18
+go 1.20

--- a/sample-apps/http-server/Dockerfile
+++ b/sample-apps/http-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.20
 
 WORKDIR /app
 COPY . .

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -23,4 +23,4 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 )
 
-go 1.18
+go 1.20


### PR DESCRIPTION
*Issue #, if available:*
https://endoflife.date/go
Go's LTS is only for latest 2 versions (1.20 and 1.19)
[dependabot's PR](https://github.com/aws/aws-xray-sdk-go/pull/400) is also failing tests for v1.16

*Description of changes:*
Update repo to test for Go v1.19 and above

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
