### PR TITLE
Lower supported version in go.mod to 1.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-xray-sdk-go
 
-go 1.20
+go 1.19
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1

--- a/integration-tests/distributioncheck/go.mod
+++ b/integration-tests/distributioncheck/go.mod
@@ -27,4 +27,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.20
+go 1.19

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -23,4 +23,4 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 )
 
-go 1.20
+go 1.19


### PR DESCRIPTION
*Issue #, if available:*
Previous PR [broke the smoke tests](https://github.com/aws/aws-xray-sdk-go/actions/runs/4257489034) due to the go.mod update https://github.com/aws/aws-xray-sdk-go/pull/403
> go: go.mod file indicates go 1.20, but maximum version supported by tidy is 1.19

*Description of changes:*
Lower go.mod supported version to 1.19


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
