### PR TITLE
Change how SDK sets the context for AWS SDK calls

### DIFF
--- a/xray/aws.go
+++ b/xray/aws.go
@@ -49,7 +49,7 @@ const (
 
 func beginSubsegment(r *request.Request, name string) {
 	ctx, _ := BeginSubsegment(r.HTTPRequest.Context(), name)
-	r.HTTPRequest = r.HTTPRequest.WithContext(ctx)
+	r.SetContext(ctx)
 }
 
 func endSubsegment(r *request.Request) {
@@ -58,7 +58,7 @@ func endSubsegment(r *request.Request) {
 		return
 	}
 	seg.Close(r.Error)
-	r.HTTPRequest = r.HTTPRequest.WithContext(context.WithValue(r.HTTPRequest.Context(), ContextKey, seg.parent))
+	r.SetContext(context.WithValue(r.HTTPRequest.Context(), ContextKey, seg.parent))
 }
 
 var xRayBeforeValidateHandler = request.NamedHandler{
@@ -71,7 +71,7 @@ var xRayBeforeValidateHandler = request.NamedHandler{
 		opseg.Namespace = "aws"
 		marshalctx, _ := BeginSubsegment(ctx, "marshal")
 
-		r.HTTPRequest = r.HTTPRequest.WithContext(marshalctx)
+		r.SetContext(marshalctx)
 		r.HTTPRequest.Header.Set(TraceIDHeaderKey, opseg.DownstreamHeader().String())
 	},
 }
@@ -91,7 +91,7 @@ var xRayBeforeSignHandler = request.NamedHandler{
 			return
 		}
 		ct, _ := NewClientTrace(ctx)
-		r.HTTPRequest = r.HTTPRequest.WithContext(httptrace.WithClientTrace(ctx, ct.httpTrace))
+		r.SetContext(httptrace.WithClientTrace(ctx, ct.httpTrace))
 	},
 }
 
@@ -139,7 +139,7 @@ var xRayBeforeRetryHandler = request.NamedHandler{
 		endSubsegment(r) // end attempt subsegment
 		ctx, _ := BeginSubsegment(r.HTTPRequest.Context(), "wait")
 
-		r.HTTPRequest = r.HTTPRequest.WithContext(ctx)
+		r.SetContext(ctx)
 	},
 }
 


### PR DESCRIPTION
### *Issue #, if available:*

Currently, `aws-xray-sdk-go` only sets the context in the `(*Request).HTTPRequest.ctx` of an AWS SDK Go v1 call to a downstream service, which will extract the context that was set here. However, sometimes a downstream service would look inside `(*Request).context` in order to extract the context.

The solution is to set the context in both of these areas, which is also how `aws-sdk-go` generally sets the context.
[AWS SDK Go Lambda API InvokeWithContext Example](https://github.com/aws/aws-sdk-go/blob/main/service/lambda/api.go#L3430-L3432)


### *Description of changes:*

This change is essentially:
```
-   r.HTTPRequest = r.HTTPRequest.WithContext(ctx)
+   r.SetContext(ctx)
```
Code flow Before:
```
(*request.Request).HTTPRequest = r.HTTPRequest.WithContext(ctx)    // Panics when ctx == nil
```
Code flow After:
```
(*request.Request).SetContext(ctx)

func (r *Request) SetContext(ctx aws.Context) {
    if ctx == nil {
        panic("context cannot be nil")
    }
    setRequestContext(r, ctx)
}

func setRequestContext(r *Request, ctx aws.Context) {
    r.context = ctx
    r.HTTPRequest = r.HTTPRequest.WithContext(ctx)
}
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
