### PR TITLE
omit URL's password when stringifying URL for segment name

### DIFF
--- a/xray/client_test.go
+++ b/xray/client_test.go
@@ -223,7 +223,7 @@ func TestRoundTripWithBasicAuth(t *testing.T) {
 	if assert.NoError(t, json.Unmarshal(seg.Subsegments[0], &subseg)) {
 		assert.Equal(t, "remote", subseg.Namespace)
 		assert.Equal(t, http.MethodGet, subseg.HTTP.Request.Method)
-		assert.Equal(t, stripURL(*u), subseg.HTTP.Request.URL)
+		assert.Equal(t, "http://user:***@127.0.0.1:"+u.Port(), subseg.HTTP.Request.URL)
 		assert.Equal(t, http.StatusOK, subseg.HTTP.Response.Status)
 		assert.Equal(t, responseContentLength, subseg.HTTP.Response.ContentLength)
 		assert.False(t, subseg.Throttle)


### PR DESCRIPTION
*Issue #421*

*Description of changes:*

Stripping basic auth password from url to avoid leak in xray traces.