### PR TITLE
Fixing integration test path

### DIFF
--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -21,7 +21,7 @@ jobs:
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
       - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
-        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' sample-apps/http-server/go.mod
 
       - name: Zip up the deployment package
         run: zip -r deploy.zip . -x '*.git*'

--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -112,7 +112,6 @@ jobs:
 
       - name: Run testing suite
         run: ./gradlew :validator:run --args='-c default-xray-trace-validation.yml --endpoint http://${{ github.run_id }}-${{ github.run_number }}-eb-app-env.us-west-2.elasticbeanstalk.com'
-        working-directory: ./sample-apps/http-server
 
   cleanup:
     name: Resource tear down

--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -21,16 +21,18 @@ jobs:
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
       - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
-        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' sample-apps/http-server/go.mod
+        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+        working-directory: ./sample-apps/http-server
 
       - name: Zip up the deployment package
         run: zip -r deploy.zip . -x '*.git*'
+        working-directory: ./sample-apps/http-server
 
       - name: Upload WebApp with X-Ray SDK build artifact
         uses: actions/upload-artifact@v2
         with:
           name: deployment-package
-          path: deploy.zip
+          path: sample-apps/http-server/deploy.zip
 
   deploy_WebApp:
     name: Deploy X-Ray Instrumented Web App

--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Copy X-Ray SDK to deployment package with Sample App
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
+      - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
+        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+
       - name: Zip up the deployment package
         run: zip -r deploy.zip . -x '*.git*'
         working-directory: ./sample-apps/http-server

--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -21,7 +21,7 @@ jobs:
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
       - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
-        run: sed -i '' 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+        run: sed -i 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
         working-directory: ./sample-apps/http-server
 
       - name: Zip up the deployment package

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -1,7 +1,6 @@
 module application.go
 
-replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go
-
+replace github.com/aws/aws-xray-sdk-go => ../../
 require (
 	github.com/aws/aws-sdk-go v1.47.9
 	github.com/aws/aws-xray-sdk-go v1.8.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the relative path for the Integration Tests for Go.
I made it so it works locally, then updated the terraform script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
