### PR TITLE
Changing sample-app go.mod redirection

### DIFF
--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -20,10 +20,13 @@ jobs:
       - name: Copy X-Ray SDK to deployment package with Sample App
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
+      - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
+        run: sed -i 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+        working-directory: ./sample-apps/http-server
+
       - name: Zip up the deployment package
         run: zip -r deploy.zip . -x '*.git*'
         working-directory: ./sample-apps/http-server
-
 
       - name: Upload WebApp with X-Ray SDK build artifact
         uses: actions/upload-artifact@v2

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -1,6 +1,6 @@
 module application.go
 
-replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go
+replace github.com/aws/aws-xray-sdk-go => ../../
 
 require (
 	github.com/aws/aws-sdk-go v1.47.9


### PR DESCRIPTION
Issue #, if available:
The sample-app does not work out of the box because the go.mod redirection points to the wrong folder.

Description of changes:
Change the redirection to 2 folders up instead. This causes an issue with EB running with Go. So we change it back for the GitHub workflows.

Other option tried:
I tried changing the folder structure of deploy.zip to get this to work without changing the text of go.mod, but this does not seem possible given the limitations of EB. This would have been the preferred option to me because I find editing code/config to to test to be higher maintenance. However, application.go must be at the working directory level. This is hard coded as a part of EB. And it is awkward to try to place the aws-xray-sdk-go folder two levels up.
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/go-environment.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.