### PR TITLE
[v1.5.1] ran unit tests with github.com/DATA-DOG/go-sqlmock v1.5.1-0.202310192…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/aws-xray-sdk-go
 go 1.19
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.4.1
+	github.com/DATA-DOG/go-sqlmock v1.5.1-0.20231019222207-b2d135c5e4bc
 	github.com/aws/aws-lambda-go v1.41.0
 	github.com/aws/aws-sdk-go v1.47.9
 	github.com/aws/aws-sdk-go-v2 v1.22.2

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.1-0.20231019222207-b2d135c5e4bc h1:OJlnshfFqtLRUgc4AcUZ7hR3zwt6i5UvlNFXD/8Wn+c=
+github.com/DATA-DOG/go-sqlmock v1.5.1-0.20231019222207-b2d135c5e4bc/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
 github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
@@ -50,6 +54,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Ran tests with custom version of https://github.com/DATA-DOG/go-sqlmock@b2d135c5e4bca66a3e7055ff43f64b245a5bc612 which will be v1.5.1.

Ran `go run ./...`

Result
```bash                                                            
?       github.com/aws/aws-xray-sdk-go/awsplugins/beanstalk     [no test files]
?       github.com/aws/aws-xray-sdk-go/awsplugins/ecs   [no test files]
ok      github.com/aws/aws-xray-sdk-go/awsplugins/ec2   0.451s
ok      github.com/aws/aws-xray-sdk-go/daemoncfg        1.003s
ok      github.com/aws/aws-xray-sdk-go/header   0.682s
?       github.com/aws/aws-xray-sdk-go/internal/plugins [no test files]
?       github.com/aws/aws-xray-sdk-go/resources        [no test files]
?       github.com/aws/aws-xray-sdk-go/utils    [no test files]
?       github.com/aws/aws-xray-sdk-go/xraylog  [no test files]
ok      github.com/aws/aws-xray-sdk-go/instrumentation/awsv2    6.449s
ok      github.com/aws/aws-xray-sdk-go/internal/logger  0.200s
ok      github.com/aws/aws-xray-sdk-go/lambda   0.777s
ok      github.com/aws/aws-xray-sdk-go/pattern  0.962s
ok      github.com/aws/aws-xray-sdk-go/strategy/ctxmissing      0.597s
ok      github.com/aws/aws-xray-sdk-go/strategy/exception       1.137s
ok      github.com/aws/aws-xray-sdk-go/strategy/sampling        1.361s
```