### PR TITLE
fix fatal error: concurrent map iteration and map write

### DIFF
--- a/instrumentation/awsv2/awsv2.go
+++ b/instrumentation/awsv2/awsv2.go
@@ -67,6 +67,9 @@ func deserializeMiddleware(stack *middleware.Stack) error {
 			return out, metadata, err
 		}
 
+		// Lock subseg before updating
+		subseg.Lock()
+
 		subseg.GetHTTP().GetResponse().ContentLength = int(resp.ContentLength)
 		requestID, ok := v2Middleware.GetRequestIDMetadata(metadata)
 
@@ -76,6 +79,8 @@ func deserializeMiddleware(stack *middleware.Stack) error {
 		if extendedRequestID := resp.Header.Get(xray.S3ExtendedRequestIDHeaderKey); extendedRequestID != "" {
 			subseg.GetAWS()[xray.ExtendedRequestIDKey] = extendedRequestID
 		}
+
+		subseg.Unlock()
 
 		xray.HttpCaptureResponse(subseg, resp.StatusCode)
 		return out, metadata, err


### PR DESCRIPTION
*Issue #, if available:*

If user config StreamingStrategy to be a small value and create many AWS SDK v2 subsegments, 2 goroutines would update the Segment at the same time, causes either `panic: runtime error: index out of range` or `fatal error: concurrent map iteration and map write`.

The panic has been addressed in PR https://github.com/aws/aws-xray-sdk-go/pull/419
The current PR is for addressing the fatal error.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
