### PR TITLE
Upgrade Go version used in sample app docker file to 1.21

### DIFF
--- a/sample-apps/http-server/Dockerfile
+++ b/sample-apps/http-server/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.20
+FROM golang:1.21
 
 WORKDIR /app
 COPY . .
-ENV GOPROXY direct
+ENV GOPROXY=direct
 
 RUN go mod download
 RUN cd sample-apps/http-server/ && go install .


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-xray-sdk-go/actions/runs/13422216580

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
