### PR TITLE
Fix for v2 release, update workflows/tests

### DIFF
--- a/.github/workflows/IntegrationTesting.yml
+++ b/.github/workflows/IntegrationTesting.yml
@@ -25,7 +25,7 @@ jobs:
         run: rsync -r * sample-apps/http-server/aws-xray-sdk-go --exclude sample-apps/
 
       - name: The application.go file must be at the working directory level in EB Go. We need to change the redirection to the folder we copied in the previous step.
-        run: sed -i 's|replace github.com/aws/aws-xray-sdk-go => ../../|replace github.com/aws/aws-xray-sdk-go => ./aws-xray-sdk-go|g' go.mod
+        run: sed -i 's|replace github.com/aws/aws-xray-sdk-go/v2 => ../../|replace github.com/aws/aws-xray-sdk-go/v2 => ./aws-xray-sdk-go|g' go.mod
         working-directory: ./sample-apps/http-server
 
       - name: Zip up the deployment package

--- a/awsplugins/beanstalk/beanstalk.go
+++ b/awsplugins/beanstalk/beanstalk.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/internal/plugins"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/plugins"
 )
 
 // Origin is the type of AWS resource that runs your application.

--- a/awsplugins/ec2/ec2.go
+++ b/awsplugins/ec2/ec2.go
@@ -13,8 +13,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/internal/plugins"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/plugins"
 )
 
 // Origin is the type of AWS resource that runs your application.
@@ -27,7 +27,7 @@ type metadata struct {
 	InstanceType     string
 }
 
-//Init activates EC2Plugin at runtime.
+// Init activates EC2Plugin at runtime.
 func Init() {
 	if plugins.InstancePluginMetadata != nil && plugins.InstancePluginMetadata.EC2Metadata == nil {
 		addPluginMetadata(plugins.InstancePluginMetadata)

--- a/awsplugins/ecs/ecs.go
+++ b/awsplugins/ecs/ecs.go
@@ -11,8 +11,8 @@ package ecs
 import (
 	"os"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/internal/plugins"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/plugins"
 )
 
 // Origin is the type of AWS resource that runs your application.

--- a/daemoncfg/daemon_config.go
+++ b/daemoncfg/daemon_config.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 	"github.com/pkg/errors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/aws-xray-sdk-go
+module github.com/aws/aws-xray-sdk-go/v2
 
 go 1.19
 

--- a/instrumentation/awsv2/awsv2.go
+++ b/instrumentation/awsv2/awsv2.go
@@ -12,9 +12,9 @@ import (
 	"context"
 
 	v2Middleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
-	"github.com/aws/aws-xray-sdk-go/xray"
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/aws/aws-xray-sdk-go/v2/xray"
 )
 
 // RequestIDKey is the key name of the request id.

--- a/instrumentation/awsv2/awsv2_test.go
+++ b/instrumentation/awsv2/awsv2_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/aws/aws-sdk-go-v2/service/route53/types"
-	"github.com/aws/aws-xray-sdk-go/strategy/ctxmissing"
-	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/ctxmissing"
+	"github.com/aws/aws-xray-sdk-go/v2/xray"
 )
 
 func TestAWSV2(t *testing.T) {

--- a/integration-tests/distributioncheck/go.mod
+++ b/integration-tests/distributioncheck/go.mod
@@ -1,9 +1,9 @@
 module distributioncheck
 
-replace github.com/aws/aws-xray-sdk-go => ../../
+replace github.com/aws/aws-xray-sdk-go/v2 => ../../
 
 require (
-	github.com/aws/aws-xray-sdk-go v1.8.0
+	github.com/aws/aws-xray-sdk-go/v2 v2.0.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/integration-tests/distributioncheck/sanity_test.go
+++ b/integration-tests/distributioncheck/sanity_test.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/aws/aws-xray-sdk-go/v2/xray"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aws/aws-xray-sdk-go/xraylog"
+	"github.com/aws/aws-xray-sdk-go/v2/xraylog"
 )
 
 // This internal package hides the actual logging functions from the user.

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/xraylog"
+	"github.com/aws/aws-xray-sdk-go/v2/xraylog"
 )
 
 func TestLogger(t *testing.T) {

--- a/sample-apps/http-server/application.go
+++ b/sample-apps/http-server/application.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-xray-sdk-go/instrumentation/awsv2"
-	"github.com/aws/aws-xray-sdk-go/xray"
+	"github.com/aws/aws-xray-sdk-go/v2/instrumentation/awsv2"
+	"github.com/aws/aws-xray-sdk-go/v2/xray"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -1,11 +1,11 @@
 module application.go
 
-replace github.com/aws/aws-xray-sdk-go => ../../
+replace github.com/aws/aws-xray-sdk-go/v2 => ../../
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.77.0
-	github.com/aws/aws-xray-sdk-go v1.8.2
+	github.com/aws/aws-xray-sdk-go/v2 v2.0.0
 	golang.org/x/net v0.33.0
 )
 

--- a/strategy/ctxmissing/ctxmissing_test.go
+++ b/strategy/ctxmissing/ctxmissing_test.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/xraylog"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/xraylog"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strategy/ctxmissing/default_context_missing.go
+++ b/strategy/ctxmissing/default_context_missing.go
@@ -8,7 +8,7 @@
 
 package ctxmissing
 
-import "github.com/aws/aws-xray-sdk-go/internal/logger"
+import "github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 
 // RuntimeErrorStrategy provides the AWS_XRAY_CONTEXT_MISSING
 // environment variable value for enabling the runtime error

--- a/strategy/exception/exception_test.go
+++ b/strategy/exception/exception_test.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/utils/awserr"
+	"github.com/aws/aws-xray-sdk-go/v2/utils/awserr"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strategy/sampling/centralized.go
+++ b/strategy/sampling/centralized.go
@@ -16,11 +16,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/daemoncfg"
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/internal/plugins"
+	"github.com/aws/aws-xray-sdk-go/v2/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/plugins"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 )
 
 // CentralizedStrategy is an implementation of SamplingStrategy. It

--- a/strategy/sampling/centralized_sampling_rule_manifest.go
+++ b/strategy/sampling/centralized_sampling_rule_manifest.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 )
 
 const defaultRule = "Default"

--- a/strategy/sampling/centralized_sampling_rule_manifest_test.go
+++ b/strategy/sampling/centralized_sampling_rule_manifest_test.go
@@ -11,7 +11,7 @@ package sampling
 import (
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strategy/sampling/centralized_test.go
+++ b/strategy/sampling/centralized_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/daemoncfg"
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strategy/sampling/localized.go
+++ b/strategy/sampling/localized.go
@@ -9,8 +9,8 @@
 package sampling
 
 import (
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/resources"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/resources"
 )
 
 // LocalizedStrategy makes trace sampling decisions based on

--- a/strategy/sampling/proxy.go
+++ b/strategy/sampling/proxy.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/aws/aws-xray-sdk-go/daemoncfg"
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 )
 
 // proxy is an implementation of svcProxy that forwards requests to the XRay daemon

--- a/strategy/sampling/proxy_test.go
+++ b/strategy/sampling/proxy_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/v2/daemoncfg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/strategy/sampling/reservoir.go
+++ b/strategy/sampling/reservoir.go
@@ -8,7 +8,7 @@
 
 package sampling
 
-import "github.com/aws/aws-xray-sdk-go/utils"
+import "github.com/aws/aws-xray-sdk-go/v2/utils"
 
 // Reservoirs allow a specified (`perSecond`) amount of `Take()`s per second.
 

--- a/strategy/sampling/reservoir_test.go
+++ b/strategy/sampling/reservoir_test.go
@@ -12,7 +12,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/strategy/sampling/sampling_rule.go
+++ b/strategy/sampling/sampling_rule.go
@@ -11,9 +11,9 @@ package sampling
 import (
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/pattern"
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/pattern"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 )
 
 // Properties is the base set of properties that define a sampling rule.

--- a/strategy/sampling/sampling_rule_manifest.go
+++ b/strategy/sampling/sampling_rule_manifest.go
@@ -15,7 +15,7 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 )
 
 // RuleManifest represents a full sampling ruleset, with a list of

--- a/strategy/sampling/sampling_rule_test.go
+++ b/strategy/sampling/sampling_rule_test.go
@@ -11,7 +11,7 @@ package sampling
 import (
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/utils"
+	"github.com/aws/aws-xray-sdk-go/v2/utils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/capture_test.go
+++ b/xray/capture_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/strategy/exception"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/exception"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/client.go
+++ b/xray/client.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 )
 
 // TraceIDHeaderKey is the HTTP header name used for tracing.

--- a/xray/config.go
+++ b/xray/config.go
@@ -14,13 +14,13 @@ import (
 	"os"
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/daemoncfg"
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/xraylog"
+	"github.com/aws/aws-xray-sdk-go/v2/daemoncfg"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/xraylog"
 
-	"github.com/aws/aws-xray-sdk-go/strategy/ctxmissing"
-	"github.com/aws/aws-xray-sdk-go/strategy/exception"
-	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/ctxmissing"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/exception"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/sampling"
 )
 
 // SDKVersion records the current X-Ray Go SDK version.

--- a/xray/config_test.go
+++ b/xray/config_test.go
@@ -16,9 +16,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/strategy/ctxmissing"
-	"github.com/aws/aws-xray-sdk-go/strategy/exception"
-	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/ctxmissing"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/exception"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/sampling"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/context_test.go
+++ b/xray/context_test.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/strategy/exception"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/exception"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/default_emitter.go
+++ b/xray/default_emitter.go
@@ -14,7 +14,7 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 )
 
 // Header is added before sending segments to daemon.

--- a/xray/default_streaming_strategy.go
+++ b/xray/default_streaming_strategy.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 )
 
 var defaultMaxSubsegmentCount uint32 = 20

--- a/xray/fasthttp.go
+++ b/xray/fasthttp.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"github.com/valyala/fasthttp"
 )
 

--- a/xray/grpc.go
+++ b/xray/grpc.go
@@ -9,14 +9,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 
 	"google.golang.org/grpc/codes"
 
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/xray/grpc_test.go
+++ b/xray/grpc_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 

--- a/xray/handler.go
+++ b/xray/handler.go
@@ -16,8 +16,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-xray-sdk-go/header"
-	"github.com/aws/aws-xray-sdk-go/pattern"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
+	"github.com/aws/aws-xray-sdk-go/v2/pattern"
 )
 
 // SegmentNamer is the interface for naming service node.

--- a/xray/handler_test.go
+++ b/xray/handler_test.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/lambda.go
+++ b/xray/lambda.go
@@ -14,8 +14,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
 )
 
 // LambdaTraceHeaderKey is key to get trace header from context.

--- a/xray/lambda_test.go
+++ b/xray/lambda_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,7 +56,7 @@ func TestLambdaMix(t *testing.T) {
 }
 
 /*
-	This helper function creates a request and validates the response using the context provided.
+This helper function creates a request and validates the response using the context provided.
 */
 func testHelper(ctx context.Context, t *testing.T, td *TestDaemon, sampled bool) {
 	var subseg = GetSegment(ctx)

--- a/xray/segment.go
+++ b/xray/segment.go
@@ -19,10 +19,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
-	"github.com/aws/aws-xray-sdk-go/internal/logger"
-	"github.com/aws/aws-xray-sdk-go/internal/plugins"
-	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/logger"
+	"github.com/aws/aws-xray-sdk-go/v2/internal/plugins"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/sampling"
 )
 
 // NewTraceID generates a string format of random trace ID.
@@ -405,7 +405,7 @@ func (seg *Segment) CloseAndStream(err error) {
 	if SdkDisabled() {
 		return
 	}
-	
+
 	if seg.parent != nil {
 		logger.Debugf("Ending subsegment named: %s", seg.Name)
 		seg.Lock()
@@ -417,7 +417,7 @@ func (seg *Segment) CloseAndStream(err error) {
 			logger.Debugf("Removing subsegment named: %s", seg.Name)
 		}
 	}
-	
+
 	seg.Lock()
 	defer seg.Unlock()
 

--- a/xray/segment_model.go
+++ b/xray/segment_model.go
@@ -13,9 +13,9 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/aws/aws-xray-sdk-go/header"
-	"github.com/aws/aws-xray-sdk-go/strategy/exception"
-	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/exception"
+	"github.com/aws/aws-xray-sdk-go/v2/strategy/sampling"
 )
 
 // Segment provides the resource's name, details about the request, and details about the work done.

--- a/xray/segment_test.go
+++ b/xray/segment_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/xray/util_test.go
+++ b/xray/util_test.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aws/aws-xray-sdk-go/header"
+	"github.com/aws/aws-xray-sdk-go/v2/header"
 )
 
 func NewTestDaemon() (context.Context, *TestDaemon) {


### PR DESCRIPTION
*Issue #, if available:*

To correctly upgrade this Go module to v2, there are 2 options:
https://go.dev/wiki/Modules#releasing-modules-v2-or-higher
This PR uses the first method of upgrading to v2.

*Description of changes:*

Change `github.com/aws/aws-xray-sdk-go` to `github.com/aws/aws-xray-sdk-go/v2` where applicable.
README changes coming later


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
