### PR TITLE
Remove older Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
           - windows-latest
           - macos-latest
         go:
-          - '1.19'
-          - '1.20'
+          - '1.23'
+          - '1.24'
           - '1'
     steps:
       - name: Set up Go ${{ matrix.go }}
@@ -45,7 +45,7 @@ jobs:
         os:
           - ubuntu-latest
         go:
-          - '1.20'
+          - '1.24'
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want additional features when tracing your Go applications, please [open 
 
 ## Installing into GOPATH
 
-The AWS X-Ray SDK for Go is compatible with Go 1.19 and above.
+The AWS X-Ray SDK for Go is compatible with Go 1.23 and above.
 
 Install the SDK using the following command (The SDK's non-testing dependencies will be installed):
 Use `go get` to retrieve the SDK to add it to your `GOPATH` workspace:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/aws-xray-sdk-go/v2
 
-go 1.19
+go 1.24
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.1

--- a/integration-tests/distributioncheck/go.mod
+++ b/integration-tests/distributioncheck/go.mod
@@ -24,4 +24,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.24

--- a/sample-apps/http-server/Dockerfile
+++ b/sample-apps/http-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.24
 
 WORKDIR /app
 COPY . .

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -38,5 +38,5 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 )
 
-go 1.21
+go 1.24
 toolchain go1.24.1


### PR DESCRIPTION
Go's LTS is only for latest 2 versions - https://endoflife.date/go

Dependabot's PR is also failing tests using old versions: https://github.com/aws/aws-xray-sdk-go/pull/501

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
