### PR TITLE
Release X-Ray Go SDK v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Unreleased
 
 ### SDK Bugs
 
+Release v2.0.2 (2026-07-09)
+===============================
+### SDK Breaking Changes
+
+### SDK Enhancements
+
+### SDK Bugs
+* Bump golang.org/x/net to v0.55.0 to address CVEs [#PR 526](https://github.com/aws/aws-xray-sdk-go/pull/526)
+
 Release v2.0.1 (2026-03-31)
 ===============================
 ### SDK Breaking Changes

--- a/xray/config.go
+++ b/xray/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 // SDKVersion records the current X-Ray Go SDK version.
-const SDKVersion = "2.0.1"
+const SDKVersion = "2.0.2"
 
 // SDKType records which X-Ray SDK customer uses.
 const SDKType = "X-Ray for Go"


### PR DESCRIPTION
## Summary
- Bump `SDKVersion` in `xray/config.go` from `2.0.1` to `2.0.2`
- Add `v2.0.2` CHANGELOG entry (golang.org/x/net → v0.55.0 CVE fix, #526)

Release PR for MCM-154163145.

## Test plan
- [x] Sanity E2E test run against master commit `3060251` (resolves x/net v0.55.0)
  - Manual trace: `ManualTraceHandler` → `MockOperation1` → `ProcessMockData`, `MockOperation2`
  - Automatic trace: `AutomaticTraceHandler` → `S3` subsegment
- [ ] Unit tests pass (CI)
- [ ] Integration tests pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)