### PR TITLE
Fix CI: bump to Go 1.25 for x/net v0.55.0

### DIFF
--- a/sample-apps/http-server/Dockerfile
+++ b/sample-apps/http-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 
 WORKDIR /app
 COPY . .

--- a/sample-apps/http-server/go.mod
+++ b/sample-apps/http-server/go.mod
@@ -38,6 +38,4 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 
-go 1.24.0
-
-toolchain go1.24.5
+go 1.25.0

--- a/terraform/eb.tf
+++ b/terraform/eb.tf
@@ -55,7 +55,7 @@ resource "aws_elastic_beanstalk_application_version" "eb_app_version" {
 resource "aws_elastic_beanstalk_environment" "eb_env" {
   name                = "${var.resource_prefix}-EB-App-Env"
   application         = aws_elastic_beanstalk_application.eb_app.name
-  solution_stack_name = "64bit Amazon Linux 2 v3.11.6 running Go 1"
+  solution_stack_name = "64bit Amazon Linux 2023 v4.9.3 running Go 1"
   tier = "WebServer"
   version_label = aws_elastic_beanstalk_application_version.eb_app_version.name
   cname_prefix = "${var.resource_prefix}-Eb-app-env"


### PR DESCRIPTION
## Summary
The v2.0.2 release (#527) pulled `golang.org/x/net@v0.55.0`, which declares `go >= 1.25.0`. This propagated into the SDK's root `go.mod` and broke two CI workflows on `master` post-merge, since both were pinned below Go 1.25:

- **ecr-publish** — `sample-apps/http-server/Dockerfile` used `golang:1.24` with `GOTOOLCHAIN=local`; `go mod download` failed with `go.mod requires go >= 1.25.0 (running go 1.24.13)`.
- **Integration Testing** — the sample app is built on-instance by the Elastic Beanstalk Go platform, which was pinned to the stale `64bit Amazon Linux 2 v3.11.6 running Go 1` stack; the build failed with `Engine execution has encountered an error`.

This cannot be resolved by lowering the Go version, because x/net v0.55.0 itself requires Go 1.25 (and downgrading it would revert the CVE fix that v2.0.2 shipped).

## Changes
- `sample-apps/http-server/Dockerfile`: `golang:1.24` → `golang:1.25`
- `sample-apps/http-server/go.mod`: `go 1.24.0` → `go 1.25.0` (drop stale `toolchain go1.24.5` pin)
- `terraform/eb.tf`: EB solution stack `AL2 v3.11.6` → `AL2023 v4.9.3 running Go 1` (ships Go 1.25.11 — verified via AWS EB platform history; also a Recommended, current platform)

## Test plan
- [ ] ecr-publish workflow succeeds on merge
- [ ] Integration Testing workflow succeeds on merge (EB deploy + trace validation)
- [ ] Test / CodeQL remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)