### PR TITLE
Release X-Ray Go SDK v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Unreleased
 
 ### SDK Bugs
 
+Release v2.0.3 (2026-07-23)
+===============================
+### SDK Breaking Changes
+
+### SDK Enhancements
+
+### SDK Bugs
+* Bump grpc, x/net, x/text to address CVEs [#PR 530](https://github.com/aws/aws-xray-sdk-go/pull/530)
+
 Release v2.0.2 (2026-07-09)
 ===============================
 ### SDK Breaking Changes

--- a/xray/config.go
+++ b/xray/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 // SDKVersion records the current X-Ray Go SDK version.
-const SDKVersion = "2.0.2"
+const SDKVersion = "2.0.3"
 
 // SDKType records which X-Ray SDK customer uses.
 const SDKType = "X-Ray for Go"


### PR DESCRIPTION
## Summary
- Bump `SDKVersion` in `xray/config.go` from `2.0.2` to `2.0.3`
- Add `v2.0.3` CHANGELOG entry (grpc, x/net, x/text CVE fixes, #530)

Release PR for the next X-Ray Go SDK release MCM.

## Test plan
- [ ] Unit tests pass (CI)
- [ ] Integration tests pass (CI)